### PR TITLE
Fix reset password sending to activation link instead of change_password link

### DIFF
--- a/blossom-core/blossom-core-user/src/main/resources/templates/mail/user-change-password.ftl
+++ b/blossom-core/blossom-core-user/src/main/resources/templates/mail/user-change-password.ftl
@@ -40,7 +40,7 @@
                 </tr>
                 <tr>
                   <td class="content-block aligncenter">
-                    <a href="${basePath}/blossom/public/activate?token=${token}&lang=${lang}" class="btn-primary">
+                    <a href="${basePath}/blossom/public/change_password?token=${token}&lang=${lang}" class="btn-primary">
                       ${message("change.password.content.action")}
                     </a>
                   </td>


### PR DESCRIPTION
When requesting a password reset, the link sent contains a "USER_RESET_PASSWORD" action token, but points to the /activate endpoint, which only accepts "USER_ACTIVATION" action token.

This fixes the url to point directly to /change_password, since we may not want to allow users to activate their account with a reset password link. If we do, we should instead change the action token type to "USER_ACTIVATION" in fr/blossom/core/user/UserMailServiceImpl.java:46