### PR TITLE
Remove double reset password token submit

### DIFF
--- a/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
+++ b/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
@@ -78,7 +78,6 @@ public class ActivationController {
 
       if (user.isPresent()) {
         UpdatePasswordForm updatePasswordForm = new UpdatePasswordForm();
-        updatePasswordForm.setToken(token);
 
         return new ModelAndView("activation/change-password", "updatePasswordForm", updatePasswordForm);
       }

--- a/blossom-ui/blossom-ui-web/src/main/resources/templates/activation/change-password.ftl
+++ b/blossom-ui/blossom-ui-web/src/main/resources/templates/activation/change-password.ftl
@@ -35,7 +35,6 @@
 
           <div class="col-lg-12">
             <form id="updatePasswordForm" class="m-t" role="form" method="POST" novalidate>
-              <input type="hidden" name="token" value="${updatePasswordForm.token}">
 
               <@spring.bind "updatePasswordForm"/>
               <#assign hasGlobalError = spring.status.error/>


### PR DESCRIPTION
When submitting the password reset form, we're still on the /reset_password?token=<token here> page.

Submitting the form causes the browser to submit the token twice:
- First as a query param
- Also as a hidden form param

Which means that instead of the token, fr/blossom/ui/web/ActivationController.java:96 tries to validate a string made of the token twice separated by a comma, and fails.

This fix removes the extra token added in the form, and assumes that we got on the page with the token as a query string.