### PR TITLE
Action token dates & activation/password reset tokens invalidation

### DIFF
--- a/blossom-autoconfigure/src/main/java/fr/blossom/autoconfigure/core/UserAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/fr/blossom/autoconfigure/core/UserAutoConfiguration.java
@@ -64,19 +64,18 @@ public class UserAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(UserMailService.class)
-  public UserMailService userMailService(MailSender mailSender,
-    ActionTokenService actionTokenService) {
-    return new UserMailServiceImpl(mailSender, actionTokenService);
+  public UserMailService userMailService(MailSender mailSender) {
+    return new UserMailServiceImpl(mailSender);
   }
 
   @Bean
   @ConditionalOnMissingBean(UserService.class)
   public UserService userService(UserDao userDao, UserDTOMapper userDTOMapper,
-    PasswordEncoder passwordEncoder, UserMailService userMailService,
+    PasswordEncoder passwordEncoder, ActionTokenService actionTokenService, UserMailService userMailService,
     ApplicationEventPublisher eventPublisher,
     @Value("classpath:/images/avatar.jpeg") Resource defaultAvatar) {
     return new UserServiceImpl(userDao, userDTOMapper, eventPublisher, associationServicePlugins, passwordEncoder,
-      userMailService, defaultAvatar);
+      actionTokenService, userMailService, defaultAvatar);
   }
 
   @Bean

--- a/blossom-core/blossom-core-common/src/main/java/fr/blossom/core/common/utils/action_token/ActionToken.java
+++ b/blossom-core/blossom-core-common/src/main/java/fr/blossom/core/common/utils/action_token/ActionToken.java
@@ -1,13 +1,13 @@
 package fr.blossom.core.common.utils.action_token;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 
 public class ActionToken {
 
   private Long userId;
   private String action;
-  private LocalDateTime expirationDate;
+  private Instant expirationDate;
   private Map<String, String> additionalParameters;
 
   public Long getUserId() {
@@ -26,16 +26,16 @@ public class ActionToken {
     this.action = action;
   }
 
-  public LocalDateTime getExpirationDate() {
+  public Instant getExpirationDate() {
     return expirationDate;
   }
 
-  public void setExpirationDate(LocalDateTime endOfValidityDate) {
+  public void setExpirationDate(Instant endOfValidityDate) {
     this.expirationDate = endOfValidityDate;
   }
 
   public boolean isValid() {
-    return expirationDate.isAfter(LocalDateTime.now());
+    return expirationDate.isAfter(Instant.now());
   }
 
   public Map<String, String> getAdditionalParameters() {

--- a/blossom-core/blossom-core-common/src/main/java/fr/blossom/core/common/utils/action_token/ActionTokenServiceImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/fr/blossom/core/common/utils/action_token/ActionTokenServiceImpl.java
@@ -48,7 +48,7 @@ public class ActionTokenServiceImpl implements ActionTokenService {
     ActionToken actionToken = new ActionToken();
     actionToken.setUserId(Long.parseLong(result.get(0)));
     actionToken.setAction(result.get(1));
-    actionToken.setExpirationDate(Instant.ofEpochMilli(Long.parseLong(result.get(2))).atZone(ZoneOffset.UTC).toLocalDateTime());
+    actionToken.setExpirationDate(Instant.ofEpochMilli(Long.parseLong(result.get(2))));
     actionToken.setAdditionalParameters(decryptAdditionalParameters(result.get(3)));
     return actionToken;
   }
@@ -64,7 +64,7 @@ public class ActionTokenServiceImpl implements ActionTokenService {
 
     Joiner joiner = Joiner.on('|');
     return joiner.join(actionToken.getUserId(), actionToken.getAction(),
-      actionToken.getExpirationDate().toInstant(ZoneOffset.UTC).toEpochMilli(),
+      actionToken.getExpirationDate().toEpochMilli(),
       encryptAdditionalParameters(actionToken.getAdditionalParameters()));
   }
 

--- a/blossom-core/blossom-core-common/src/test/java/fr/blossom/core/common/utils/action_token/ActionTokenServiceImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/fr/blossom/core/common/utils/action_token/ActionTokenServiceImplTest.java
@@ -1,21 +1,8 @@
 package fr.blossom.core.common.utils.action_token;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.List;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,6 +11,19 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.security.core.token.DefaultToken;
 import org.springframework.security.core.token.TokenService;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ActionTokenServiceImplTest {
@@ -42,7 +42,7 @@ public class ActionTokenServiceImplTest {
 
   @Test
   public void should_encrypt_action_token_to_string() throws Exception {
-    LocalDateTime time = LocalDateTime.now().plusHours(1);
+    Instant time = Instant.now().plus(1, ChronoUnit.HOURS);
 
     ActionToken action = new ActionToken();
     action.setAction("test");
@@ -55,7 +55,7 @@ public class ActionTokenServiceImplTest {
     List<String> splitted = Splitter.on("|").splitToList(result);
     assertEquals(splitted.get(0), action.getUserId().toString());
     assertEquals(splitted.get(1), action.getAction());
-    assertEquals(splitted.get(2), time.toInstant(ZoneOffset.UTC).toEpochMilli() + "");
+    assertEquals(splitted.get(2), time.toEpochMilli() + "");
     assertTrue(splitted.get(3).length() == 0);
   }
 
@@ -66,7 +66,7 @@ public class ActionTokenServiceImplTest {
     ActionToken action = new ActionToken();
     action.setAction(null);
     action.setUserId(1L);
-    action.setExpirationDate(LocalDateTime.now().plusHours(1));
+    action.setExpirationDate(Instant.now().plus(1, ChronoUnit.HOURS));
     action.setAdditionalParameters(Maps.newHashMap());
 
     service.encryptTokenAsString(action);
@@ -79,7 +79,7 @@ public class ActionTokenServiceImplTest {
     ActionToken action = new ActionToken();
     action.setAction("test");
     action.setUserId(null);
-    action.setExpirationDate(LocalDateTime.now().plusHours(1));
+    action.setExpirationDate(Instant.now().plus(1, ChronoUnit.HOURS));
     action.setAdditionalParameters(Maps.newHashMap());
 
     service.encryptTokenAsString(action);
@@ -138,8 +138,7 @@ public class ActionTokenServiceImplTest {
 
     assertEquals(token.getUserId(), userId);
     assertEquals(token.getAction(), action);
-    assertEquals(token.getExpirationDate().toInstant(ZoneOffset.UTC).toEpochMilli(),
-      (long) timestamp);
+    assertEquals(token.getExpirationDate().toEpochMilli(), (long) timestamp);
     assertTrue(token.isValid());
   }
 
@@ -219,7 +218,7 @@ public class ActionTokenServiceImplTest {
     ActionToken action = new ActionToken();
     action.setAction("test");
     action.setUserId(1L);
-    action.setExpirationDate(LocalDateTime.now().plusHours(1));
+    action.setExpirationDate(Instant.now().plus(1, ChronoUnit.HOURS));
     action
       .setAdditionalParameters(ImmutableMap.<String, String>builder().put("test", "test").build());
 
@@ -246,8 +245,7 @@ public class ActionTokenServiceImplTest {
     assertNotNull(token);
     assertEquals(token.getUserId(), userId);
     assertEquals(token.getAction(), action);
-    assertEquals(token.getExpirationDate().toInstant(ZoneOffset.UTC).toEpochMilli(),
-      (long) timestamp);
+    assertEquals(token.getExpirationDate().toEpochMilli(), (long) timestamp);
     assertTrue(token.isValid());
   }
 
@@ -265,8 +263,7 @@ public class ActionTokenServiceImplTest {
     assertNotNull(token);
     assertEquals(token.getUserId(), userId);
     assertEquals(token.getAction(), action);
-    assertEquals(token.getExpirationDate().toInstant(ZoneOffset.UTC).toEpochMilli(),
-      (long) timestamp);
+    assertEquals(token.getExpirationDate().toEpochMilli(), (long) timestamp);
     assertFalse(token.isValid());
   }
 }

--- a/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserMailService.java
+++ b/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserMailService.java
@@ -5,8 +5,8 @@ package fr.blossom.core.user;
  */
 public interface UserMailService {
 
-  void sendAccountCreationEmail(UserDTO user) throws Exception;
+  void sendAccountCreationEmail(UserDTO user, String token) throws Exception;
 
-  void sendChangePasswordEmail(UserDTO user) throws Exception;
+  void sendChangePasswordEmail(UserDTO user, String token) throws Exception;
 
 }

--- a/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserMailServiceImpl.java
+++ b/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserMailServiceImpl.java
@@ -1,6 +1,7 @@
 package fr.blossom.core.user;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import com.google.common.base.Preconditions;
@@ -29,7 +30,7 @@ public class UserMailServiceImpl implements UserMailService {
     ActionToken actionToken = new ActionToken();
     actionToken.setAction(UserService.USER_ACTIVATION);
     actionToken.setUserId(user.getId());
-    actionToken.setExpirationDate(LocalDateTime.now().plusDays(3));
+    actionToken.setExpirationDate(Instant.now().plus(3, ChronoUnit.DAYS));
 
     Map<String, Object> ctx = Maps.newHashMap();
     ctx.put("user", user);
@@ -45,7 +46,7 @@ public class UserMailServiceImpl implements UserMailService {
     ActionToken actionToken = new ActionToken();
     actionToken.setAction(UserService.USER_RESET_PASSWORD);
     actionToken.setUserId(user.getId());
-    actionToken.setExpirationDate(LocalDateTime.now().plusHours(3));
+    actionToken.setExpirationDate(Instant.now().plus(3, ChronoUnit.HOURS));
 
     Map<String, Object> ctx = Maps.newHashMap();
     ctx.put("user", user);

--- a/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserMailServiceImpl.java
+++ b/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserMailServiceImpl.java
@@ -1,56 +1,40 @@
 package fr.blossom.core.user;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Map;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-
-import fr.blossom.core.common.utils.action_token.ActionToken;
-import fr.blossom.core.common.utils.action_token.ActionTokenService;
 import fr.blossom.core.common.utils.mail.MailSender;
+
+import java.util.Map;
 
 public class UserMailServiceImpl implements UserMailService {
 
   private final MailSender mailSender;
-  private final ActionTokenService tokenService;
 
-  public UserMailServiceImpl(MailSender mailSender, ActionTokenService tokenService) {
+  public UserMailServiceImpl(MailSender mailSender) {
     Preconditions.checkNotNull(mailSender);
-    Preconditions.checkNotNull(tokenService);
     this.mailSender = mailSender;
-    this.tokenService = tokenService;
   }
 
   @Override
-  public void sendAccountCreationEmail(UserDTO user) throws Exception {
+  public void sendAccountCreationEmail(UserDTO user, String token) throws Exception {
     Preconditions.checkNotNull(user);
-
-    ActionToken actionToken = new ActionToken();
-    actionToken.setAction(UserService.USER_ACTIVATION);
-    actionToken.setUserId(user.getId());
-    actionToken.setExpirationDate(Instant.now().plus(3, ChronoUnit.DAYS));
+    Preconditions.checkNotNull(token);
 
     Map<String, Object> ctx = Maps.newHashMap();
     ctx.put("user", user);
-    ctx.put("token", this.tokenService.generateToken(actionToken));
+    ctx.put("token", token);
 
     this.mailSender.sendMail("user-activation", ctx, "activation.subject", user.getLocale(), user.getEmail());
   }
 
   @Override
-  public void sendChangePasswordEmail(UserDTO user) throws Exception {
+  public void sendChangePasswordEmail(UserDTO user, String token) throws Exception {
     Preconditions.checkNotNull(user);
-
-    ActionToken actionToken = new ActionToken();
-    actionToken.setAction(UserService.USER_RESET_PASSWORD);
-    actionToken.setUserId(user.getId());
-    actionToken.setExpirationDate(Instant.now().plus(3, ChronoUnit.HOURS));
+    Preconditions.checkNotNull(token);
 
     Map<String, Object> ctx = Maps.newHashMap();
     ctx.put("user", user);
-    ctx.put("token", this.tokenService.generateToken(actionToken));
+    ctx.put("token", token);
 
     this.mailSender.sendMail("user-change-password", ctx, "change.password.subject", user.getLocale(), user.getEmail());
   }

--- a/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserService.java
+++ b/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserService.java
@@ -1,6 +1,7 @@
 package fr.blossom.core.user;
 
 import fr.blossom.core.common.service.CrudService;
+import fr.blossom.core.common.utils.action_token.ActionToken;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,6 +22,16 @@ public interface UserService extends CrudService<UserDTO> {
   Optional<UserDTO> getByEmail(String email);
 
   Optional<UserDTO> getById(Long id);
+
+  /**
+   * Return the user (if any) identified by an ActionToken produced by this service.
+   * Since these ActionToken are made to activate/retrieve a user password, they are
+   * invalidated once the user manages to login once.
+   *
+   * @param actionToken Action token obtained by email sent by this service
+   * @return optional UserDTO, present if the actionToken was obtained after the last user login
+   */
+  Optional<UserDTO> getByActionToken(ActionToken actionToken);
 
   UserDTO update(Long userId, UserUpdateForm userUpdateForm);
 

--- a/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserService.java
+++ b/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserService.java
@@ -47,4 +47,11 @@ public interface UserService extends CrudService<UserDTO> {
 
   InputStream loadAvatar(long id) throws IOException;
 
+  /**
+   * Generate a valid password reset token for a user
+   * @param userDTO User which password should be reset with this token
+   * @return A valid password reset token
+   */
+  String generatePasswordResetToken(UserDTO userDTO);
+
 }

--- a/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserServiceImpl.java
+++ b/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserServiceImpl.java
@@ -105,7 +105,7 @@ public class UserServiceImpl extends GenericCrudServiceImpl<UserDTO, User> imple
     UserDTO userDTO = optionalUserDTO.get();
     Date creationDate = new Date(Long.parseLong(actionToken.getAdditionalParameters().get(creationDateParameter)));
 
-    if (creationDate.before(userDTO.getLastConnection())) {
+    if (userDTO.getLastConnection() != null && creationDate.before(userDTO.getLastConnection())) {
       return Optional.empty();
     }
 
@@ -199,8 +199,7 @@ public class UserServiceImpl extends GenericCrudServiceImpl<UserDTO, User> imple
     return tokenService.generateToken(actionToken);
   }
 
-  @VisibleForTesting
-  protected String generatePasswordResetToken(UserDTO user) {
+  public String generatePasswordResetToken(UserDTO user) {
     ActionToken actionToken = new ActionToken();
     actionToken.setAction(UserService.USER_RESET_PASSWORD);
     actionToken.setUserId(user.getId());

--- a/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserServiceImpl.java
+++ b/blossom-core/blossom-core-user/src/main/java/fr/blossom/core/user/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package fr.blossom.core.user;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import fr.blossom.core.common.dto.AbstractDTO;
 import fr.blossom.core.common.event.CreatedEvent;
@@ -7,17 +8,20 @@ import fr.blossom.core.common.event.UpdatedEvent;
 import fr.blossom.core.common.mapper.DTOMapper;
 import fr.blossom.core.common.service.AssociationServicePlugin;
 import fr.blossom.core.common.service.GenericCrudServiceImpl;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Date;
-import java.util.Optional;
-import java.util.UUID;
+import fr.blossom.core.common.utils.action_token.ActionToken;
+import fr.blossom.core.common.utils.action_token.ActionTokenService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.Resource;
 import org.springframework.plugin.core.PluginRegistry;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
 
 /**
  * Created by Maël Gargadennnec on 03/05/2017.
@@ -26,20 +30,27 @@ public class UserServiceImpl extends GenericCrudServiceImpl<UserDTO, User> imple
 
   private final PasswordEncoder passwordEncoder;
   private final UserDao userDao;
+  private final ActionTokenService tokenService;
   private final UserMailService userMailService;
   private final Resource defaultAvatar;
 
-  public UserServiceImpl(UserDao dao, DTOMapper<User, UserDTO> mapper,
+  private final String creationDateParameter = "creationDate";
+
+  public UserServiceImpl(
+    UserDao dao, DTOMapper<User, UserDTO> mapper,
     ApplicationEventPublisher publisher,
     PluginRegistry<AssociationServicePlugin, Class<? extends AbstractDTO>> associationRegistry,
-    PasswordEncoder passwordEncoder, UserMailService userMailService, Resource defaultAvatar) {
+    PasswordEncoder passwordEncoder, ActionTokenService tokenService, UserMailService userMailService,
+    Resource defaultAvatar) {
     super(dao, mapper, publisher, associationRegistry);
     Preconditions.checkNotNull(passwordEncoder);
     Preconditions.checkNotNull(dao);
+    Preconditions.checkNotNull(tokenService);
     Preconditions.checkNotNull(userMailService);
     Preconditions.checkNotNull(defaultAvatar);
     this.passwordEncoder = passwordEncoder;
     this.userDao = dao;
+    this.tokenService = tokenService;
     this.userMailService = userMailService;
     this.defaultAvatar = defaultAvatar;
   }
@@ -60,7 +71,7 @@ public class UserServiceImpl extends GenericCrudServiceImpl<UserDTO, User> imple
     user.setActivated(false);
 
     UserDTO savedUser = this.mapper.mapEntity(this.userDao.create(user));
-    userMailService.sendAccountCreationEmail(savedUser);
+    userMailService.sendAccountCreationEmail(savedUser, generateActivationToken(savedUser));
 
     this.publisher.publishEvent(new CreatedEvent<>(this, savedUser));
 
@@ -80,6 +91,25 @@ public class UserServiceImpl extends GenericCrudServiceImpl<UserDTO, User> imple
   @Override
   public Optional<UserDTO> getById(Long id) {
     return Optional.ofNullable(mapper.mapEntity(this.userDao.getOne(id)));
+  }
+
+  @Override
+  public Optional<UserDTO> getByActionToken(ActionToken actionToken) {
+    Preconditions.checkState(actionToken.isValid(), "Invalid token");
+    Preconditions.checkNotNull(actionToken.getAdditionalParameters().get(creationDateParameter));
+
+    Optional<UserDTO> optionalUserDTO = getById(actionToken.getUserId());
+    if (!optionalUserDTO.isPresent()) {
+      return Optional.empty();
+    }
+    UserDTO userDTO = optionalUserDTO.get();
+    Date creationDate = new Date(Long.parseLong(actionToken.getAdditionalParameters().get(creationDateParameter)));
+
+    if (creationDate.before(userDTO.getLastConnection())) {
+      return Optional.empty();
+    }
+
+    return optionalUserDTO;
   }
 
   @Override
@@ -128,7 +158,7 @@ public class UserServiceImpl extends GenericCrudServiceImpl<UserDTO, User> imple
   public void askPasswordChange(long userId) throws Exception {
     UserDTO user = this
       .updatePassword(userId, passwordEncoder.encode(UUID.randomUUID().toString()));
-    userMailService.sendChangePasswordEmail(user);
+    userMailService.sendChangePasswordEmail(user, generatePasswordResetToken(user));
   }
 
   @Override
@@ -153,5 +183,33 @@ public class UserServiceImpl extends GenericCrudServiceImpl<UserDTO, User> imple
 
   protected String generateRandomPasswordHash() {
     return passwordEncoder.encode(UUID.randomUUID().toString());
+  }
+
+  @VisibleForTesting
+  protected String generateActivationToken(UserDTO user) {
+    ActionToken actionToken = new ActionToken();
+    actionToken.setAction(UserService.USER_ACTIVATION);
+    actionToken.setUserId(user.getId());
+    actionToken.setExpirationDate(Instant.now().plus(3, ChronoUnit.DAYS));
+
+    Map<String, String> additionalParameters = new HashMap<>();
+    additionalParameters.put(creationDateParameter, Long.toString(Instant.now().toEpochMilli()));
+    actionToken.setAdditionalParameters(additionalParameters);
+
+    return tokenService.generateToken(actionToken);
+  }
+
+  @VisibleForTesting
+  protected String generatePasswordResetToken(UserDTO user) {
+    ActionToken actionToken = new ActionToken();
+    actionToken.setAction(UserService.USER_RESET_PASSWORD);
+    actionToken.setUserId(user.getId());
+    actionToken.setExpirationDate(Instant.now().plus(3, ChronoUnit.HOURS));
+
+    Map<String, String> additionalParameters = new HashMap<>();
+    additionalParameters.put(creationDateParameter, Long.toString(Instant.now().toEpochMilli()));
+    actionToken.setAdditionalParameters(additionalParameters);
+
+    return tokenService.generateToken(actionToken);
   }
 }

--- a/blossom-core/blossom-core-user/src/test/java/fr/blossom/core/user/UserMailServiceImplTest.java
+++ b/blossom-core/blossom-core-user/src/test/java/fr/blossom/core/user/UserMailServiceImplTest.java
@@ -25,19 +25,14 @@ public class UserMailServiceImplTest {
   @Mock
   private MailSender mailSender;
 
-  @Mock
-  private ActionTokenService tokenService;
-
   @Spy
   @InjectMocks
   private UserMailServiceImpl userMailService;
 
   @Test
-  public void test_send_change_password_email_user_not_null() throws Exception {
+  public void test_send_change_password_email_user_not_null_token_not_null() throws Exception {
 
-    BDDMockito.given(tokenService.generateToken(BDDMockito.any(ActionToken.class))).willReturn("any");
-
-    userMailService.sendChangePasswordEmail(new UserDTO());
+    userMailService.sendChangePasswordEmail(new UserDTO(), "token !");
 
     BDDMockito.verify(mailSender, BDDMockito.times(1)).sendMail(BDDMockito.anyString(), BDDMockito.any(),
         BDDMockito.anyString(), BDDMockito.any(Locale.class), BDDMockito.anyString());
@@ -46,15 +41,19 @@ public class UserMailServiceImplTest {
   @Test
   public void test_send_change_password_email_user_null() throws Exception {
     thrown.expect(NullPointerException.class);
-    userMailService.sendChangePasswordEmail(null);
+    userMailService.sendChangePasswordEmail(null, "token !");
   }
 
   @Test
-  public void test_send_account_creation_email_user_not_null() throws Exception {
+  public void test_send_change_password_email_token_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+    userMailService.sendChangePasswordEmail(new UserDTO(), null);
+  }
 
-    BDDMockito.given(tokenService.generateToken(BDDMockito.any(ActionToken.class))).willReturn("any");
+  @Test
+  public void test_send_account_creation_email_user_not_null_token_not_null() throws Exception {
 
-    userMailService.sendAccountCreationEmail(new UserDTO());
+    userMailService.sendAccountCreationEmail(new UserDTO(), "token !");
 
     BDDMockito.verify(mailSender, BDDMockito.times(1)).sendMail(BDDMockito.anyString(), BDDMockito.any(),
         BDDMockito.anyString(), BDDMockito.any(Locale.class), BDDMockito.anyString());
@@ -63,24 +62,24 @@ public class UserMailServiceImplTest {
   @Test
   public void test_send_account_creation_email_user_null() throws Exception {
     thrown.expect(NullPointerException.class);
-    userMailService.sendAccountCreationEmail(null);
+    userMailService.sendAccountCreationEmail(null, "token !");
+  }
+
+  @Test
+  public void test_send_account_creation_email_token_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+    userMailService.sendAccountCreationEmail(new UserDTO(), null);
   }
 
   @Test
   public void test_user_mail_service_impl_nothing_null() throws Exception {
-    new UserMailServiceImpl(mailSender, tokenService);
+    new UserMailServiceImpl(mailSender);
   }
 
   @Test
   public void test_user_mail_service_impl_user_mail_service_null() throws Exception {
     thrown.expect(NullPointerException.class);
-    new UserMailServiceImpl(null, tokenService);
-  }
-
-  @Test
-  public void test_user_mail_service_impl_token_service_null() throws Exception {
-    thrown.expect(NullPointerException.class);
-    new UserMailServiceImpl(mailSender, null);
+    new UserMailServiceImpl(null);
   }
 
 }

--- a/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
+++ b/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
@@ -6,7 +6,9 @@ import fr.blossom.core.user.UserDTO;
 import fr.blossom.core.user.UserService;
 import fr.blossom.core.validation.FieldMatch;
 import fr.blossom.ui.stereotype.BlossomController;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
@@ -56,7 +58,7 @@ public class ActivationController {
 
         ActionToken passwordResetToken = new ActionToken();
         passwordResetToken.setAction(UserService.USER_RESET_PASSWORD);
-        passwordResetToken.setExpirationDate(LocalDateTime.now().plusMinutes(30));
+        passwordResetToken.setExpirationDate(Instant.now().plus(30, ChronoUnit.MINUTES));
         passwordResetToken.setUserId(userId);
 
         return "redirect:/blossom/public/change_password?token=" + this.tokenService.generateToken(passwordResetToken);

--- a/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
+++ b/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
@@ -6,26 +6,25 @@ import fr.blossom.core.user.UserDTO;
 import fr.blossom.core.user.UserService;
 import fr.blossom.core.validation.FieldMatch;
 import fr.blossom.ui.stereotype.BlossomController;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Optional;
-import javax.validation.Valid;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 @BlossomController
 @RequestMapping("/public")
@@ -61,6 +60,10 @@ public class ActivationController {
         passwordResetToken.setExpirationDate(Instant.now().plus(30, ChronoUnit.MINUTES));
         passwordResetToken.setUserId(userId);
 
+        Map<String, String> additionalParameters = new HashMap<>();
+        additionalParameters.put("creationDate", Long.toString(Instant.now().toEpochMilli()));
+        actionToken.setAdditionalParameters(additionalParameters);
+
         return "redirect:/blossom/public/change_password?token=" + this.tokenService.generateToken(passwordResetToken);
       }
     }
@@ -76,7 +79,7 @@ public class ActivationController {
       return new ModelAndView(new RedirectView("/blossom"));
     }
     if (actionToken.isValid() && actionToken.getAction().equals(UserService.USER_RESET_PASSWORD)) {
-      Optional<UserDTO> user = this.userService.getById(actionToken.getUserId());
+      Optional<UserDTO> user = this.userService.getByActionToken(actionToken);
 
       if (user.isPresent()) {
         UpdatePasswordForm updatePasswordForm = new UpdatePasswordForm();
@@ -101,7 +104,7 @@ public class ActivationController {
     }
 
     if (actionToken.isValid() && actionToken.getAction().equals(UserService.USER_RESET_PASSWORD)) {
-      Optional<UserDTO> user = this.userService.getById(actionToken.getUserId());
+      Optional<UserDTO> user = this.userService.getByActionToken(actionToken);
 
       if (user.isPresent()) {
         this.userService.updatePassword(user.get().getId(), updatePasswordForm.getPassword());
@@ -141,8 +144,8 @@ public class ActivationController {
     @NotEmpty
     private String token;
 
-    @NotEmpty(message="{change.password.validation.NotEmpty.message}")
-    @Size(min=8, message="{change.password.validation.Size.message}")
+    @NotEmpty(message = "{change.password.validation.NotEmpty.message}")
+    @Size(min = 8, message = "{change.password.validation.Size.message}")
     @Pattern.List({
       @Pattern(regexp = "(?=.*[0-9]).+", message = "{change.password.validation.Pattern.digit.message}"),
       @Pattern(regexp = "(?=.*[a-z]).+", message = "{change.password.validation.Pattern.lowercase.message}"),
@@ -178,8 +181,8 @@ public class ActivationController {
   }
 
   public static class AskPasswordForm {
-    @NotEmpty(message="{ask.password.validation.NotEmpty.message}")
-    private String loginOrEmail ="";
+    @NotEmpty(message = "{ask.password.validation.NotEmpty.message}")
+    private String loginOrEmail = "";
 
     public String getLoginOrEmail() {
       return loginOrEmail;

--- a/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
+++ b/blossom-ui/blossom-ui-web/src/main/java/fr/blossom/ui/web/ActivationController.java
@@ -19,11 +19,6 @@ import org.springframework.web.servlet.view.RedirectView;
 import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @BlossomController
@@ -50,21 +45,12 @@ public class ActivationController {
       return "redirect:/blossom";
     }
     if (actionToken.isValid() && actionToken.getAction().equals(UserService.USER_ACTIVATION)) {
-      Optional<UserDTO> user = this.userService.getById(actionToken.getUserId());
+      Optional<UserDTO> user = this.userService.getByActionToken(actionToken);
       if (user.isPresent()) {
         Long userId = user.get().getId();
         this.userService.updateActivation(userId, true);
 
-        ActionToken passwordResetToken = new ActionToken();
-        passwordResetToken.setAction(UserService.USER_RESET_PASSWORD);
-        passwordResetToken.setExpirationDate(Instant.now().plus(30, ChronoUnit.MINUTES));
-        passwordResetToken.setUserId(userId);
-
-        Map<String, String> additionalParameters = new HashMap<>();
-        additionalParameters.put("creationDate", Long.toString(Instant.now().toEpochMilli()));
-        actionToken.setAdditionalParameters(additionalParameters);
-
-        return "redirect:/blossom/public/change_password?token=" + this.tokenService.generateToken(passwordResetToken);
+        return "redirect:/blossom/public/change_password?token=" + userService.generatePasswordResetToken(user.get());
       }
     }
     return "redirect:/blossom";


### PR DESCRIPTION
- Changed the "expiration date" to an Instant in ActionToken, so that timezone difference can not cause trouble (for example for applications with multiple instances that may have different default timezones, but shared stateless tokens).

- Added token invalidation once a user logs in for tokens allowing it to activate its account, or reset its password. Assumption is that once the user manages to log in, it didn't need that token anymore.

To this end, activation/password reset tokens are now generated from the UserServiceImpl and nowhere else, so we are free to put any additional needed parameters in the token. Right now the creation time is added.