### PR TITLE
Add kotlin source language for project initializr

### DIFF
--- a/blossom-tools/blossom-tools-initializr/pom.xml
+++ b/blossom-tools/blossom-tools-initializr/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>maven-model</artifactId>
       <version>3.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>kotlinpoet</artifactId>
+      <version>0.6.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/InitializrController.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/InitializrController.java
@@ -1,6 +1,9 @@
 package fr.blossom.initializr;
 
 import javax.servlet.http.HttpServletResponse;
+
+import fr.blossom.initializr.enums.PACKAGING_MODE;
+import fr.blossom.initializr.enums.SOURCE_LANGUAGE;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
@@ -32,6 +35,7 @@ public class InitializrController {
     model.addAttribute("project", new ProjectConfiguration("blossom-starter-basic"));
     model.addAttribute("initializr", initializr);
     model.addAttribute("packagingModes", PACKAGING_MODE.values());
+    model.addAttribute("sourceLanguages", SOURCE_LANGUAGE.values());
 
     return new ModelAndView("main");
   }

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/InitializrController.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/InitializrController.java
@@ -18,7 +18,7 @@ import org.springframework.web.servlet.ModelAndView;
  * Created by Maël Gargadennnec on 14/06/2017.
  */
 @Controller
-@RequestMapping("/initializr")
+@RequestMapping("")
 public class InitializrController {
 
   private final Initializr initializr;
@@ -30,7 +30,12 @@ public class InitializrController {
     this.projectGenerator = projectGenerator;
   }
 
-  @GetMapping
+  @GetMapping("")
+  public String redirectInitializr() {
+    return "redirect:/initializr";
+  }
+
+  @GetMapping("/initializr")
   public ModelAndView main(Model model) {
     model.addAttribute("project", new ProjectConfiguration("blossom-starter-basic"));
     model.addAttribute("initializr", initializr);
@@ -40,7 +45,7 @@ public class InitializrController {
     return new ModelAndView("main");
   }
 
-  @PostMapping(produces = "application/zip")
+  @PostMapping(produces = "application/zip", value="/initializr")
   public void generate(@ModelAttribute("form") ProjectConfiguration projectConfiguration,
     HttpServletResponse res)
     throws Exception {

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/ProjectConfiguration.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/ProjectConfiguration.java
@@ -1,5 +1,8 @@
 package fr.blossom.initializr;
 
+import fr.blossom.initializr.enums.PACKAGING_MODE;
+import fr.blossom.initializr.enums.SOURCE_LANGUAGE;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -14,6 +17,7 @@ public class ProjectConfiguration {
   private String description = "Demo project for Blossom";
   private String packageName = "com.example.demo";
   private PACKAGING_MODE packagingMode = PACKAGING_MODE.JAR;
+  private SOURCE_LANGUAGE sourceLanguage = SOURCE_LANGUAGE.JAVA;
 
   private String version = "";
   private List<String> dependencies = new ArrayList<>();
@@ -89,4 +93,11 @@ public class ProjectConfiguration {
     this.packagingMode = packagingMode;
   }
 
+  public SOURCE_LANGUAGE getSourceLanguage() {
+    return sourceLanguage;
+  }
+
+  public void setSourceLanguage(SOURCE_LANGUAGE sourceLanguage) {
+    this.sourceLanguage = sourceLanguage;
+  }
 }

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/ProjectGenerator.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/ProjectGenerator.java
@@ -18,6 +18,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import fr.blossom.initializr.enums.PACKAGING_MODE;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/Version.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/Version.java
@@ -6,6 +6,7 @@ package fr.blossom.initializr;
 public class Version {
   private String blossom;
   private String springboot;
+  private String kotlin;
 
   public String getBlossom() {
     return blossom;
@@ -21,5 +22,13 @@ public class Version {
 
   public void setSpringboot(String springboot) {
     this.springboot = springboot;
+  }
+
+  public String getKotlin() {
+    return kotlin;
+  }
+
+  public void setKotlin(String kotlin) {
+    this.kotlin = kotlin;
   }
 }

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/enums/PACKAGING_MODE.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/enums/PACKAGING_MODE.java
@@ -1,4 +1,4 @@
-package fr.blossom.initializr;
+package fr.blossom.initializr.enums;
 
 public enum PACKAGING_MODE {
 

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/enums/SOURCE_LANGUAGE.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/enums/SOURCE_LANGUAGE.java
@@ -1,6 +1,24 @@
 package fr.blossom.initializr.enums;
 
 public enum SOURCE_LANGUAGE {
-  JAVA,
-  KOTLIN,
+  JAVA("Java", true),
+  JAVA_KOTLIN("Java + Kotlin", false),
+  KOTLIN("Kotlin", false),
+  ;
+
+  private final String displayName;
+  private final boolean isDefault;
+
+  SOURCE_LANGUAGE(String displayName, boolean isDefault) {
+    this.displayName = displayName;
+    this.isDefault = isDefault;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public boolean isDefault() {
+    return isDefault;
+  }
 }

--- a/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/enums/SOURCE_LANGUAGE.java
+++ b/blossom-tools/blossom-tools-initializr/src/main/java/fr/blossom/initializr/enums/SOURCE_LANGUAGE.java
@@ -1,0 +1,6 @@
+package fr.blossom.initializr.enums;
+
+public enum SOURCE_LANGUAGE {
+  JAVA,
+  KOTLIN,
+}

--- a/blossom-tools/blossom-tools-initializr/src/main/resources/application.yml
+++ b/blossom-tools/blossom-tools-initializr/src/main/resources/application.yml
@@ -5,6 +5,7 @@ initializr:
   versions:
     - blossom: 1.0.0-SNAPSHOT
       springboot: 2.0.0.M7
+      kotlin: 1.2.21
   groups:
     - name: Core
       description: Blossom core functionalities

--- a/blossom-tools/blossom-tools-initializr/src/main/resources/templates/main.ftl
+++ b/blossom-tools/blossom-tools-initializr/src/main/resources/templates/main.ftl
@@ -103,7 +103,7 @@
             <div class="col-sm-10">
               <select class="form-control" name="sourceLanguage">
                 <#list sourceLanguages as sourceLanguage>
-                  <option value="${sourceLanguage}">${sourceLanguage}</option>
+                  <option value="${sourceLanguage.name()}" <#if (sourceLanguage.default)!false>selected="selected"</#if>>${sourceLanguage.displayName}</option>
                 </#list>
               </select>
             </div>

--- a/blossom-tools/blossom-tools-initializr/src/main/resources/templates/main.ftl
+++ b/blossom-tools/blossom-tools-initializr/src/main/resources/templates/main.ftl
@@ -71,7 +71,11 @@
           <div class="form-group">
             <label class="col-sm-2 control-label">Packaging mode</label>
             <div class="col-sm-10">
-              <select class="form-control" name="packagingMode"><#list packagingModes as packagingMode><option value="${packagingMode}">${packagingMode}</option></#list></select>
+              <select class="form-control" name="packagingMode">
+                <#list packagingModes as packagingMode>
+                  <option value="${packagingMode}">${packagingMode}</option>
+                </#list>
+              </select>
             </div>
           </div>
         </div>
@@ -92,6 +96,16 @@
             <label class="col-sm-2 control-label">Package name</label>
             <div class="col-sm-10">
               <input class="form-control" type="text" name="packageName" value="${project.packageName}"/>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label">Sources language</label>
+            <div class="col-sm-10">
+              <select class="form-control" name="sourceLanguage">
+                <#list sourceLanguages as sourceLanguage>
+                  <option value="${sourceLanguage}">${sourceLanguage}</option>
+                </#list>
+              </select>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Add a "source language" option for the project initializr, with the following options:
- Java (default)
- Mixed Java + Kotlin
- Kotlin only

The configurations are taken from [kotlin doc](https://kotlinlang.org/docs/reference/using-maven.html) : Java + Kotlin allows to have sources in both java (src/main/java) and kotlin (src/main/kotlin) in the same project. Kotlin-only replaces java and the only source directory becomes src/main/kotlin.

Kotlin source generation uses [kotlinpoet](https://github.com/square/kotlinpoet) and could be improved a bit...