### PR TITLE
Fix dashboard link in home.ftl 

### DIFF
--- a/blossom-ui/blossom-ui-web/src/main/resources/templates/blossom/home/home.ftl
+++ b/blossom-ui/blossom-ui-web/src/main/resources/templates/blossom/home/home.ftl
@@ -27,7 +27,7 @@
     <div class="error-desc">
       You can create here any grid layout you want. And any variation layout you imagine:) Check out
       main dashboard and other site. It use many different layout.
-      <br><a href="index.html" class="btn btn-primary m-t">Dashboard</a>
+      <br><a href="/blossom/system/dashboard" class="btn btn-primary m-t">Dashboard</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The "Dashboard" button on the backoffice homepage points to http://localhost:8080/index.html and return "Page not found error page".
I think it should points to the backoffice dashboard at http://localhost:8080/blossom/system/dashboard

![image](https://user-images.githubusercontent.com/17550678/36213178-5b73349c-11a6-11e8-901a-fc7bcf4b9d18.png)

