### PR TITLE
Add spring-boot-configuration-processor to autoconfigure

### DIFF
--- a/blossom-autoconfigure/pom.xml
+++ b/blossom-autoconfigure/pom.xml
@@ -111,5 +111,12 @@
             <version>1.0.0-SNAPSHOT</version>
             <optional>true</optional>
         </dependency>
+
+        <!-- Generate spring-configuration-metadata.json on process -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Adding the spring-boot-configuration-processor to classpath, even as optional, creates spring-configuration-metadata.json in the correct path.

This provides IDE with auto-completion for blossom-related configuration.

![image](https://user-images.githubusercontent.com/9880933/36611119-baec84fe-18d2-11e8-88d4-7f956a6dd45f.png)
