### PR TITLE
HikariCP-java6 exclusion

### DIFF
--- a/blossom-core/blossom-core-scheduler/pom.xml
+++ b/blossom-core/blossom-core-scheduler/pom.xml
@@ -21,6 +21,16 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-quartz</artifactId>
+      <exclusions>
+
+        <!-- blossom-core-common already depends on spring-boot-starter-data-jpa which brings a newer HikariCP version,
+        relied upon by spring-boot-starter-actuator. Having this being loaded before HikariCP would prevent startup -->
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java6</artifactId>
+        </exclusion>
+
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Exclude HikariCP-java6:2.3.13 from spring-boot-starter-quartz for cases when it would get loaded before HikariCP:2.7.8, causing the application to fail starting at all : spring-boot-starter-actuator relies on methods not present in version 2.3.13.