### PR TITLE
Fix mail filters

### DIFF
--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
@@ -56,8 +56,11 @@ public class MailAutoConfiguration {
   @Bean
   @ConditionalOnBean(JavaMailSender.class)
   @ConditionalOnMissingBean(MailSender.class)
-  public MailSender blossomMailSender(JavaMailSender javaMailSender, MessageSource messageSource,
-                                      freemarker.template.Configuration configuration, Set<Locale> availableLocales, MailsenderProperties properties) {
+  public MailSender blossomMailSender(JavaMailSender javaMailSender,
+                                      MessageSource messageSource,
+                                      freemarker.template.Configuration configuration,
+                                      Set<Locale> availableLocales,
+                                      MailsenderProperties properties) {
     return new MailSenderImpl(javaMailSender,
       configuration,
       properties.getFilters(),

--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
@@ -1,48 +1,69 @@
 package com.blossomproject.autoconfigure.core;
 
-import com.google.common.collect.Iterables;
 import com.blossomproject.core.common.utils.mail.MailSender;
 import com.blossomproject.core.common.utils.mail.MailSenderImpl;
 import com.blossomproject.core.common.utils.mail.NoopMailSenderImpl;
-import java.util.Locale;
-import java.util.Set;
-import org.springframework.beans.factory.annotation.Value;
+import com.google.common.collect.Iterables;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.mail.javamail.JavaMailSender;
 
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
 @Configuration
 @ConditionalOnMissingBean(MailSender.class)
 @AutoConfigureAfter(MailSenderAutoConfiguration.class)
-@PropertySource({"classpath:/mailsender.properties"})
 public class MailAutoConfiguration {
 
-  @Value("${blossom.mail.url}")
-  String baseUrl;
+  @Configuration
+  @ConfigurationProperties("blossom.mail")
+  @PropertySource({"classpath:/mailsender.properties"})
+  public static class MailsenderProperties {
+    private String baseUrl;
+    private String from;
+    private final Set<String> filters = new HashSet<>();
 
-  @Value("${blossom.mail.from}")
-  String from;
+    public String getBaseUrl() {
+      return baseUrl;
+    }
 
-  @Value("${blossom.mail.filters}")
-  Set<String> filters;
+    public void setBaseUrl(String baseUrl) {
+      this.baseUrl = baseUrl;
+    }
+
+    public String getFrom() {
+      return from;
+    }
+
+    public void setFrom(String from) {
+      this.from = from;
+    }
+
+    public Set<String> getFilters() {
+      return filters;
+    }
+  }
 
   @Bean
   @ConditionalOnBean(JavaMailSender.class)
   @ConditionalOnMissingBean(MailSender.class)
   public MailSender blossomMailSender(JavaMailSender javaMailSender, MessageSource messageSource,
-    freemarker.template.Configuration configuration, Set<Locale> availableLocales) {
+                                      freemarker.template.Configuration configuration, Set<Locale> availableLocales, MailsenderProperties properties) {
     return new MailSenderImpl(javaMailSender,
       configuration,
-      filters,
+      properties.getFilters(),
       messageSource,
-      from,
-      baseUrl,
+      properties.getFrom(),
+      properties.getBaseUrl(),
       Iterables.getFirst(availableLocales, Locale.ENGLISH));
   }
 

--- a/blossom-autoconfigure/src/main/resources/mailsender.properties
+++ b/blossom-autoconfigure/src/main/resources/mailsender.properties
@@ -1,3 +1,3 @@
 blossom.mail.url=http://localhost:8080
 blossom.mail.from=blossom@blossom-project.com
-blossom.mail.filters=.*
+blossom.mail.filters[0]=.*


### PR DESCRIPTION
With the previous configuration, I was unable to have more than one mail filter, no matter what I tried to put in my configurations to override the default.

After this change, the following syntaxes all work to override the filter:

---
application.properties
```properties
blossom.mail.filters=test@cardiweb.com
```
Result: one filter, `test@cardiweb.com`

---
application.properties
```properties
blossom.mail.filters=test@cardiweb.com,test2@cardiweb.com
```
Result: two filters, `test@cardiweb.com` and `test2@cardiweb.com`

---
application.properties
```properties
blossom.mail.filters[0]=test@cardiweb.com
blossom.mail.filters[1]=test2@cardiweb.com
```
Result: two filters, `test@cardiweb.com` and `test2@cardiweb.com`

---
application.yml
```yaml
blossom.mail.filters: "test@cardiweb.com"
```
Result: one filter, `test@cardiweb.com`

---
application.yml
```yaml
blossom.mail.filters:
  - "test@cardiweb.com"
  - "test2@cardiweb.com"
```
Result: two filters, `test@cardiweb.com` and `test2@cardiweb.com`