### PR TITLE
Add filter on request/response headers indexed in Elasticsearch

### DIFF
--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/ActuatorAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/ActuatorAutoConfiguration.java
@@ -7,17 +7,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import java.io.IOException;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.Client;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.trace.http.HttpTraceAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Created by Maël Gargadennnec on 11/05/2017.
@@ -28,15 +32,35 @@ import org.springframework.core.io.Resource;
 @PropertySource("classpath:/actuator.properties")
 public class ActuatorAutoConfiguration {
 
+  @Configuration("BlossomActuatorAutoConfigurationTraceProperties")
+  @ConfigurationProperties("blossom.actuator.traces")
+  @PropertySource("classpath:/actuator.properties")
+  public static class TraceProperties {
+    private final Set<String> excludedRequestHeaders = new HashSet<>();
+    private final Set<String> excludedResponseHeaders = new HashSet<>();
+
+    public Set<String> getExcludedRequestHeaders() {
+      return excludedRequestHeaders;
+    }
+
+    public Set<String> getExcludedResponseHeaders() {
+      return excludedResponseHeaders;
+    }
+  }
+
   @Bean
-  public ElasticsearchTraceRepository traceRepository(Client client, BulkProcessor bulkProcessor,
-    @Value("classpath:/elasticsearch/traces.json") Resource resource, ObjectMapper objectMapper)
+  public ElasticsearchTraceRepository traceRepository(
+    Client client, BulkProcessor bulkProcessor,
+    @Value("classpath:/elasticsearch/traces.json") Resource resource,
+    ObjectMapper objectMapper,
+    TraceProperties traceProperties)
     throws IOException {
     String settings = Resources.toString(resource.getURL(), Charsets.UTF_8);
 
-    return new ElasticsearchTraceRepositoryImpl(client, bulkProcessor,"traces", Lists
+    return new ElasticsearchTraceRepositoryImpl(client, bulkProcessor, "traces", Lists
       .newArrayList("/blossom.*", "/favicon.*", "/js.*", "/css.*", "/fonts.*", "/img.*",
-        "/font-awesome.*"), settings, objectMapper);
+        "/font-awesome.*"), traceProperties.getExcludedRequestHeaders(), traceProperties.getExcludedResponseHeaders(),
+      settings, objectMapper);
   }
 
   @Bean

--- a/blossom-autoconfigure/src/main/resources/actuator.properties
+++ b/blossom-autoconfigure/src/main/resources/actuator.properties
@@ -1,2 +1,8 @@
 management.endpoints.web.exposure.include=info,health,tracesstats
 management.endpoints.web.base-path=/blossom/actuator
+
+blossom.actuator.traces.excluded-request-headers[0]=authorization
+blossom.actuator.traces.excluded-request-headers[1]=x-*
+blossom.actuator.traces.excluded-request-headers[2]=cookie
+
+blossom.actuator.traces.excluded-response-headers[0]=set-cookie

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/actuator/ElasticsearchTraceRepositoryImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/actuator/ElasticsearchTraceRepositoryImpl.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.trace.http.HttpTrace;
 import org.springframework.boot.actuate.trace.http.InMemoryHttpTraceRepository;
-import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.util.AntPathMatcher;
 

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/actuator/ElasticsearchTraceRepositoryImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/actuator/ElasticsearchTraceRepositoryImplTest.java
@@ -1,22 +1,8 @@
 package com.blossomproject.core.common.actuator;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import java.util.List;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Client;
@@ -26,6 +12,15 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.actuate.trace.http.HttpTrace;
 import org.springframework.boot.actuate.trace.http.HttpTraceCreator;
+
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 ;
 
@@ -47,7 +42,7 @@ public class ElasticsearchTraceRepositoryImplTest {
     this.alias = "test";
     this.objectMapper = new ObjectMapper();
     this.repository = spy(
-      new ElasticsearchTraceRepositoryImpl(client, bulkProcessor,"test", ignoredPatterns, "{}", objectMapper));
+      new ElasticsearchTraceRepositoryImpl(client, bulkProcessor, "test", ignoredPatterns, Collections.emptySet(), Collections.emptySet(), "{}", objectMapper));
 
     doNothing().when(this.repository).initializeIndex();
   }

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/actuator/ElasticsearchTraceRepositoryImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/actuator/ElasticsearchTraceRepositoryImplTest.java
@@ -14,7 +14,9 @@ import org.springframework.boot.actuate.trace.http.HttpTrace;
 import org.springframework.boot.actuate.trace.http.HttpTraceCreator;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static junit.framework.TestCase.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,7 +44,8 @@ public class ElasticsearchTraceRepositoryImplTest {
     this.alias = "test";
     this.objectMapper = new ObjectMapper();
     this.repository = spy(
-      new ElasticsearchTraceRepositoryImpl(client, bulkProcessor, "test", ignoredPatterns, Collections.emptySet(), Collections.emptySet(), "{}", objectMapper));
+      new ElasticsearchTraceRepositoryImpl(client, bulkProcessor, "test", ignoredPatterns,
+        Collections.singleton("authorization"), Collections.singleton("set-cookie"), "{}", objectMapper));
 
     doNothing().when(this.repository).initializeIndex();
   }
@@ -98,5 +101,32 @@ public class ElasticsearchTraceRepositoryImplTest {
     List<HttpTrace> traces = this.repository.findAll();
     assertFalse(traces.isEmpty());
     assertEquals(traceInfo, traces.get(0));
+  }
+
+  @Test
+  public void should_filter_headers() {
+    Map<String, List<String>> requestHeaders = new HashMap<>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
+
+    requestHeaders.put("Authorization", Collections.emptyList());
+    requestHeaders.put("Host", Collections.emptyList());
+    responseHeaders.put("Set-Cookie", Collections.emptyList());
+    responseHeaders.put("Date", Collections.emptyList());
+
+    HttpTrace traceInfo = HttpTraceCreator.createHttpTraceMock("/test", requestHeaders, responseHeaders);
+
+    IndexRequestBuilder mockedRequest = mock(IndexRequestBuilder.class);
+    when(mockedRequest.setSource(anyString())).thenAnswer(invocation -> {
+      String arg = invocation.getArgument(0);
+      assertFalse(arg.contains("Authorization"));
+      assertTrue(arg.contains("Host"));
+      assertFalse(arg.contains("Set-Cookie"));
+      assertTrue(arg.contains("Date"));
+      return mockedRequest;
+    });
+
+    when(this.client.prepareIndex(eq(alias), eq(alias))).thenReturn(mockedRequest);
+
+    this.repository.add(traceInfo);
   }
 }

--- a/blossom-core/blossom-core-common/src/test/java/org/springframework/boot/actuate/trace/http/HttpTraceCreator.java
+++ b/blossom-core/blossom-core-common/src/test/java/org/springframework/boot/actuate/trace/http/HttpTraceCreator.java
@@ -1,13 +1,15 @@
 package org.springframework.boot.actuate.trace.http;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 public class HttpTraceCreator {
-  public static HttpTrace createHttpTraceMock(String uri){
+  public static HttpTrace createHttpTraceMock(String uri) {
     TraceableRequest request = mock(TraceableRequest.class);
     try {
       when(request.getUri()).thenReturn(new URI(uri));
@@ -15,5 +17,23 @@ public class HttpTraceCreator {
       e.printStackTrace();
     }
     return new HttpTrace(request);
+  }
+
+  public static HttpTrace createHttpTraceMock(String uri, Map<String, List<String>> requestHeaders, Map<String, List<String>> responseHeaders) {
+    TraceableRequest request = mock(TraceableRequest.class);
+    try {
+      when(request.getUri()).thenReturn(new URI(uri));
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    when(request.getHeaders()).thenReturn(requestHeaders);
+    HttpTrace ret = new HttpTrace(request);
+
+    TraceableResponse traceableResponse = mock(TraceableResponse.class);
+    when(traceableResponse.getHeaders()).thenReturn(responseHeaders);
+    HttpTrace.Response response = new HttpTrace.Response(traceableResponse);
+    ret.setResponse(response);
+
+    return ret;
   }
 }


### PR DESCRIPTION
Do not blindly index all headers, as they may contain sensitive information.

By default, excluded headers are:
- For requests:
  - Authorization
  - All custom "X-*" headers
  - Cookies

- For responses:
  - Cookies