### PR TITLE
Supervision status page improvements

### DIFF
--- a/blossom-ui/blossom-ui-web/src/main/java/com/blossomproject/ui/web/StatusController.java
+++ b/blossom-ui/blossom-ui-web/src/main/java/com/blossomproject/ui/web/StatusController.java
@@ -56,16 +56,16 @@ public class StatusController {
 
   @VisibleForTesting
   Health filteredDetails(Health health, List<String> excludes) {
-    if (health.getDetails().isEmpty()) {
-      return health;
-    }
-
     Map<String, Health> filteredHealth = health
       .getDetails()
       .entrySet()
       .stream()
       .filter(mapEntry -> mapEntry.getValue() instanceof Health && !excludes.contains(mapEntry.getKey()))
       .collect(Collectors.toMap(Map.Entry::getKey, e -> filteredDetails((Health) e.getValue(), excludes)));
+
+    if (filteredHealth.isEmpty()) {
+      return Health.status(health.getStatus()).build();
+    }
 
     return healthAggregator.aggregate(filteredHealth);
   }

--- a/blossom-ui/blossom-ui-web/src/main/java/com/blossomproject/ui/web/StatusController.java
+++ b/blossom-ui/blossom-ui-web/src/main/java/com/blossomproject/ui/web/StatusController.java
@@ -43,7 +43,7 @@ public class StatusController {
           .get()
           .stream()
           .map(String::toLowerCase)
-          .map(s -> toString().isEmpty() ? "." : (s.startsWith(".") ? s.toLowerCase() : "." + s.toLowerCase()))
+          .map(s -> toString().isEmpty() ? "." : "." + s.toLowerCase())
           .collect(Collectors.toList()),
         "");
     }

--- a/blossom-ui/blossom-ui-web/src/main/java/com/blossomproject/ui/web/StatusController.java
+++ b/blossom-ui/blossom-ui-web/src/main/java/com/blossomproject/ui/web/StatusController.java
@@ -83,7 +83,7 @@ public class StatusController {
       .stream()
       .filter(mapEntry -> mapEntry.getValue() instanceof Health && includes.stream().anyMatch(pattern -> pattern.startsWith(currentDepth + "." + mapEntry.getKey().toLowerCase())))
       .map(mapEntry -> {
-        if (includes.stream().anyMatch(pattern -> pattern.startsWith(currentDepth + "." + mapEntry.getKey().toLowerCase()))) {
+        if (includes.stream().anyMatch(pattern -> pattern.equals(currentDepth + "." + mapEntry.getKey().toLowerCase()))) {
           return new AbstractMap.SimpleEntry<>(mapEntry.getKey(), (Health) mapEntry.getValue());
         } else {
           return new AbstractMap.SimpleEntry<>(mapEntry.getKey(), includedDetails((Health) mapEntry.getValue(), includes, currentDepth + "." + mapEntry.getKey().toLowerCase()));

--- a/blossom-ui/blossom-ui-web/src/test/java/com/blossomproject/ui/web/StatusControllerTest.java
+++ b/blossom-ui/blossom-ui-web/src/test/java/com/blossomproject/ui/web/StatusControllerTest.java
@@ -1,18 +1,13 @@
 package com.blossomproject.ui.web;
 
 import com.google.common.collect.Lists;
-
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthEndpoint;
-import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.health.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -21,114 +16,200 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StatusControllerTest {
 
-    @Mock
-    HealthEndpoint healthEndpoint;
+  @Mock
+  HealthEndpoint healthEndpoint;
 
-    @InjectMocks
-    @Spy
-    private StatusController controller;
+  @InjectMocks
+  @Spy
+  private StatusController controller;
 
-    @Test
-    public void should_display_all_status_with_health_up() throws Exception {
-        Map<String, String> map = new HashMap<>();
-        map.put("test", "testMessage");
-        Health.Builder builder = new Health.Builder(Status.UP, map);
-        Health health = builder.build();
-        
-        doReturn(health).when(controller).filteredDetails(any(), any(List.class));
+  @Test
+  public void should_display_all_status_with_health_up() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("test", "testMessage");
+    Health.Builder builder = new Health.Builder(Status.UP, map);
+    Health health = builder.build();
 
-        ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.empty());
+    doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-        assertNotNull(response);
-        assertTrue(response.getStatusCode() == HttpStatus.OK);
-        assertEquals(health, response.getBody());
-    }
+    ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.empty());
 
-    @Test
-    public void should_display_all_status_with_health_down() throws Exception {
-        Map<String, String> map = new HashMap<>();
-        map.put("test", "testMessage");
-        Health.Builder builder = new Health.Builder(Status.DOWN, map);
-        Health health = builder.build();
-        
-        doReturn(health).when(controller).filteredDetails(any(), any(List.class));
+    assertNotNull(response);
+    assertTrue(response.getStatusCode() == HttpStatus.OK);
+    assertEquals(health, response.getBody());
+  }
 
-        ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.empty());
+  @Test
+  public void should_display_all_status_with_health_down() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("test", "testMessage");
+    Health.Builder builder = new Health.Builder(Status.DOWN, map);
+    Health health = builder.build();
 
-        assertNotNull(response);
-        assertTrue(response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR);
-        assertEquals(health, response.getBody());
-    }
+    doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-    @Test
-    public void should_display_status_up_with_excludes() throws Exception {
-        Map<String, String> map = new HashMap<>();
-        map.put("test", "testMessage");
-        Health.Builder builder = new Health.Builder(Status.UP, map);
-        Health health = builder.build();
+    ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.empty());
 
-        doReturn(health).when(controller).filteredDetails(any(), any(List.class));
+    assertNotNull(response);
+    assertTrue(response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR);
+    assertEquals(health, response.getBody());
+  }
 
-        ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")), Optional.empty());
+  @Test
+  public void should_display_status_up_with_excludes() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("test", "testMessage");
+    Health.Builder builder = new Health.Builder(Status.UP, map);
+    Health health = builder.build();
 
-        assertNotNull(response);
-        assertTrue(response.getStatusCode() == HttpStatus.OK);
-        assertEquals(health, response.getBody());
-    }
+    doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-    @Test
-    public void should_display_status_down_without_excludes() throws Exception {
-        Map<String, String> map = new HashMap<>();
-        map.put("test", "testMessage");
-        Health.Builder builder = new Health.Builder(Status.DOWN, map);
-        Health health = builder.build();
+    ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")), Optional.empty());
 
-        doReturn(health).when(controller).filteredDetails(any(), any(List.class));
+    assertNotNull(response);
+    assertTrue(response.getStatusCode() == HttpStatus.OK);
+    assertEquals(health, response.getBody());
+  }
 
-        ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")), Optional.empty());
+  @Test
+  public void should_display_status_down_without_excludes() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("test", "testMessage");
+    Health.Builder builder = new Health.Builder(Status.DOWN, map);
+    Health health = builder.build();
 
-        assertNotNull(response);
-        assertTrue(response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR);
-        assertEquals(health, response.getBody());
-    }
+    doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-    @Test
-    public void should_filter_details_without_excludes() throws Exception {
-        Health.Builder builder = new Health.Builder(Status.DOWN);
-        Health healthChild = builder.build();
-        Health.Builder builder2 = new Health.Builder(Status.DOWN);
-        builder2.withDetail("healthChild", healthChild);
-        Health health = builder2.build();
+    ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")), Optional.empty());
 
-        Health healthResponse = controller.filteredDetails(health, Lists.newArrayList());
-        assertNotNull(healthResponse);
-        assertEquals(health, healthResponse);
+    assertNotNull(response);
+    assertTrue(response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR);
+    assertEquals(health, response.getBody());
+  }
 
-    }
+  @Test
+  public void should_filter_details_without_excludes() throws Exception {
+    Health.Builder builder = new Health.Builder(Status.DOWN);
+    Health healthChild = builder.build();
+    Health.Builder builder2 = new Health.Builder(Status.DOWN);
+    builder2.withDetail("healthChild", healthChild);
+    Health health = builder2.build();
 
-    @Test
-    public void should_filter_details_with_excludes() throws Exception {
-        Health.Builder builder = new Health.Builder(Status.DOWN);
-        Health healthChild = builder.build();
-        Health.Builder builder2 = new Health.Builder(Status.DOWN);
-        builder2.withDetail("healthChild", healthChild);
-        Health health = builder2.build();
+    Health healthResponse = controller.filteredDetails(health, Lists.newArrayList());
+    assertNotNull(healthResponse);
+    assertEquals(health, healthResponse);
 
-        Health healthResponse = controller.filteredDetails(health, Lists.newArrayList("healthChild"));
-        assertNotNull(healthResponse);
-        assertTrue(healthResponse.getDetails().isEmpty());
+  }
 
-    }
+  @Test
+  public void should_filter_details_with_excludes() throws Exception {
+    Health.Builder builder = new Health.Builder(Status.DOWN);
+    Health healthChild = builder.build();
+    Health.Builder builder2 = new Health.Builder(Status.DOWN);
+    builder2.withDetail("healthChild", healthChild);
+    Health health = builder2.build();
+
+    Health healthResponse = controller.filteredDetails(health, Lists.newArrayList("healthChild"));
+    assertNotNull(healthResponse);
+    assertTrue(healthResponse.getDetails().isEmpty());
+
+  }
+
+  private Health buildTestHealth() {
+    HealthAggregator aggregator = new OrderedHealthAggregator();
+
+    Health healthLeafDown = Health.down().build();
+    Health healthLeafUp = Health.up().build();
+
+    Map<String, Health> downSubRootChildren = new HashMap<>();
+    downSubRootChildren.put("healthLeafDown", healthLeafDown);
+    downSubRootChildren.put("healthLeafUp", healthLeafUp);
+    Health downSubRoot = aggregator.aggregate(downSubRootChildren);
+
+    Map<String, Health> upSubRootChildren = new HashMap<>();
+    upSubRootChildren.put("healthLeafUp", healthLeafUp);
+    upSubRootChildren.put("healthLeafStillUp", healthLeafUp);
+    Health upSubRoot = aggregator.aggregate(upSubRootChildren);
+
+    Map<String, Health> level2SubRootMap = new HashMap<>();
+    level2SubRootMap.put("downSubRoot", downSubRoot);
+    level2SubRootMap.put("upSubRoot", upSubRoot);
+    Health level2SubRoot = aggregator.aggregate(level2SubRootMap);
+
+    Map<String, Health> returnMap = new HashMap<>();
+    returnMap.put("level2SubRoot", level2SubRoot);
+    returnMap.put("upSubRoot", upSubRoot);
+    return aggregator.aggregate(returnMap);
+  }
+
+  @Test
+  public void should_display_status_down_without_includes() {
+    Health health = buildTestHealth();
+    doReturn(health).when(healthEndpoint).health();
+    ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.empty());
+
+    assertNotNull(response);
+    assertSame(response.getStatusCode(), HttpStatus.INTERNAL_SERVER_ERROR);
+    assertEquals(health, response.getBody());
+  }
+
+  @Test
+  public void should_display_status_up_with_includes() {
+    Health health = buildTestHealth();
+    doReturn(health).when(healthEndpoint).health();
+    ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.of(Lists.newArrayList("upSubRoot")));
+
+    assertNotNull(response);
+    assertSame(response.getStatusCode(), HttpStatus.OK);
+    assertTrue(response.getBody().getDetails().keySet().contains("upSubRoot"));
+    assertFalse(response.getBody().getDetails().keySet().contains("level2SubRoot"));
+  }
+
+  @Test
+  public void should_display_status_up_with_includes_and_exlcludes() {
+    Health health = buildTestHealth();
+    doReturn(health).when(healthEndpoint).health();
+    ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("healthLeafDown")), Optional.of(Lists.newArrayList("level2SubRoot.downSubRoot")));
+
+    assertNotNull(response);
+    assertSame(response.getStatusCode(), HttpStatus.OK);
+    assertFalse(response.getBody().getDetails().keySet().contains("upSubRoot"));
+    assertTrue(response.getBody().getDetails().keySet().contains("level2SubRoot"));
+    assertFalse(((Health)response.getBody().getDetails().get("level2SubRoot")).getDetails().keySet().contains("upSubRoot"));
+  }
+
+  @Test
+  public void should_display_status_up_with_includes_leaf() {
+    Health health = buildTestHealth();
+    doReturn(health).when(healthEndpoint).health();
+    ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.of(Lists.newArrayList("level2SubRoot.downSubRoot.healthLeafUp")));
+
+    assertNotNull(response);
+    assertSame(response.getStatusCode(), HttpStatus.OK);
+    assertFalse(response.getBody().getDetails().keySet().contains("upSubRoot"));
+    assertTrue(response.getBody().getDetails().keySet().contains("level2SubRoot"));
+    assertTrue(((Health)response.getBody().getDetails().get("level2SubRoot")).getDetails().keySet().contains("downSubRoot"));
+  }
+
+  @Test
+  public void should_display_root_if_leaf_health() {
+    Health health = Health.up().build();
+    doReturn(health).when(healthEndpoint).health();
+
+    ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.of(Lists.newArrayList("")));
+
+    assertNotNull(response);
+    assertSame(response.getStatusCode(), HttpStatus.OK);
+    assertTrue(response.getBody().getDetails().isEmpty());
+
+  }
 
 
 }

--- a/blossom-ui/blossom-ui-web/src/test/java/com/blossomproject/ui/web/StatusControllerTest.java
+++ b/blossom-ui/blossom-ui-web/src/test/java/com/blossomproject/ui/web/StatusControllerTest.java
@@ -47,7 +47,7 @@ public class StatusControllerTest {
         
         doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-        ResponseEntity<Health> response = controller.status(Optional.empty());
+        ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.empty());
 
         assertNotNull(response);
         assertTrue(response.getStatusCode() == HttpStatus.OK);
@@ -63,7 +63,7 @@ public class StatusControllerTest {
         
         doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-        ResponseEntity<Health> response = controller.status(Optional.empty());
+        ResponseEntity<Health> response = controller.status(Optional.empty(), Optional.empty());
 
         assertNotNull(response);
         assertTrue(response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR);
@@ -79,7 +79,7 @@ public class StatusControllerTest {
 
         doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-        ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")));
+        ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")), Optional.empty());
 
         assertNotNull(response);
         assertTrue(response.getStatusCode() == HttpStatus.OK);
@@ -95,7 +95,7 @@ public class StatusControllerTest {
 
         doReturn(health).when(controller).filteredDetails(any(), any(List.class));
 
-        ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")));
+        ResponseEntity<Health> response = controller.status(Optional.of(Lists.newArrayList("test1", "test2")), Optional.empty());
 
         assertNotNull(response);
         assertTrue(response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR);

--- a/blossom-ui/blossom-ui-web/src/test/java/com/blossomproject/ui/web/StatusControllerTest.java
+++ b/blossom-ui/blossom-ui-web/src/test/java/com/blossomproject/ui/web/StatusControllerTest.java
@@ -40,7 +40,7 @@ public class StatusControllerTest {
 
     @Test
     public void should_display_all_status_with_health_up() throws Exception {
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put("test", "testMessage");
         Health.Builder builder = new Health.Builder(Status.UP, map);
         Health health = builder.build();
@@ -56,7 +56,7 @@ public class StatusControllerTest {
 
     @Test
     public void should_display_all_status_with_health_down() throws Exception {
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put("test", "testMessage");
         Health.Builder builder = new Health.Builder(Status.DOWN, map);
         Health health = builder.build();
@@ -72,7 +72,7 @@ public class StatusControllerTest {
 
     @Test
     public void should_display_status_up_with_excludes() throws Exception {
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put("test", "testMessage");
         Health.Builder builder = new Health.Builder(Status.UP, map);
         Health health = builder.build();
@@ -88,7 +88,7 @@ public class StatusControllerTest {
 
     @Test
     public void should_display_status_down_without_excludes() throws Exception {
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put("test", "testMessage");
         Health.Builder builder = new Health.Builder(Status.DOWN, map);
         Health health = builder.build();


### PR DESCRIPTION
- Changed the filtered health status to use an `OrderedHealthAggregator` to accurately represent the filtered result
- Added ability to selectively include healths with names allowing nested selections.

  For example, if `curl http://localhost:8080/blossom/public/status` answers:
```json
{
  "status": "DOWN",
  "details": {
    "upSubRoot": {
      "status": "UP",
      "details": {
        "healthLeafUp": {
          "status": "UP"
        },
        "healthLeafStillUp": {
          "status": "UP"
        }
      }
    },
    "level2SubRoot": {
      "status": "DOWN",
      "details": {
        "upSubRoot": {
          "status": "UP",
          "details": {
            "healthLeafUp": {
              "status": "UP"
            },
            "healthLeafStillUp": {
              "status": "UP"
            }
          }
        },
        "downSubRoot": {
          "status": "DOWN",
          "details": {
            "healthLeafDown": {
              "status": "DOWN"
            },
            "healthLeafUp": {
              "status": "UP"
            }
          }
        }
      }
    }
  }
}
```

Then `curl http://localhost:8080/blossom/public/status?include=level2SubRoot.downSubRoot.healthLeafUp` returns:
```json
{
  "status": "UP",
  "details": {
    "level2SubRoot": {
      "status": "UP",
      "details": {
        "downSubRoot": {
          "status": "UP",
          "details": {
            "healthLeafUp": {
              "status": "UP"
            }
          }
        }
      }
    }
  }
}
```