### PR TITLE
Automated changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,8 @@ fabric.properties
 
 .idea/
 *.iml
+.okhttpcache
+
+# Ignore duplicate changelogs created for submodules
+CHANGELOG.md
+!/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,385 @@
+# Changelog
+
+## Unreleased
+- Add the missing import spring in master.ftl [#139](https://github.com/blossom-project/blossom/pull/139)  
+- User profile page [#142](https://github.com/blossom-project/blossom/issues/142)  
+- User impersonation [#143](https://github.com/blossom-project/blossom/issues/143)  
+- Fix mail filters [#144](https://github.com/blossom-project/blossom/pull/144)  
+- Search filters [#145](https://github.com/blossom-project/blossom/pull/145)  
+- Revert the change from `blossom.mail.url` to `blossom.mail.base-url` [#148](https://github.com/blossom-project/blossom/pull/148)  
+- Provide a copy constructor for AbstractDTO [#149](https://github.com/blossom-project/blossom/pull/149)  
+- Add Cc and Bcc recipients to mail sender and allow customisation of an email parameter by adding a mailfilter [#150](https://github.com/blossom-project/blossom/pull/150)  
+- Add filter on request/response headers indexed in Elasticsearch [#152](https://github.com/blossom-project/blossom/pull/152)  
+- Supervision status page improvements [#156](https://github.com/blossom-project/blossom/pull/156)  
+- Fix profile page for users with empty values [#157](https://github.com/blossom-project/blossom/pull/157)  
+
+### No issue
+- Removing the sample generator
+- Use BulkProcessor for http traces
+- Using bulk to index httptraces
+- Moving impersonation freemarker to utils
+- Facultative aggregation registry
+- Update bcprov & bcmail versions
+- Update property default value
+- Update README.md
+- Fix typo
+- Prepare next version
+
+
+## 1.0.0
+- getAll() cache (again) [#125](https://github.com/blossom-project/blossom/issues/125)  
+
+### No issue
+- Pom refinement
+- Avatar update fix
+- Two minor corrections (avatar update + scheduler display on small devices)
+- Prepare release
+
+
+## 1.0.0.M2
+- Back-office homepage with submenu items as cards [#101](https://github.com/blossom-project/blossom/pull/101)  
+- UserApiController avatar tests + Administration Web tests [#102](https://github.com/blossom-project/blossom/pull/102)  
+- Generator UI Back-office create, display, edit and delete functions [#103](https://github.com/blossom-project/blossom/pull/103)  
+- Add spring-boot-configuration-processor to autoconfigure [#104](https://github.com/blossom-project/blossom/pull/104)  
+- Generator : Enum Type + Indexation Elasticsearch [#105](https://github.com/blossom-project/blossom/pull/105)  
+- Generator : Textarea input for @Lob String [#106](https://github.com/blossom-project/blossom/pull/106)  
+- Back-office homepage with panel for each menuItem. [#107](https://github.com/blossom-project/blossom/pull/107)  
+- Generator : ApiController generation [#108](https://github.com/blossom-project/blossom/pull/108)  
+- Generator : Fix changelog Path + Fix IndexationJob Qualifier [#109](https://github.com/blossom-project/blossom/pull/109)  
+- getAll() cache [#113](https://github.com/blossom-project/blossom/issues/113)  
+- Manual cache usage and cache disabling [#114](https://github.com/blossom-project/blossom/issues/114)  
+- Add link of the documentation website in the read me file [#117](https://github.com/blossom-project/blossom/pull/117)  
+- Fix in askForForgottenPassword POST Controller. [#118](https://github.com/blossom-project/blossom/pull/118)  
+- Tests on Article module [#119](https://github.com/blossom-project/blossom/pull/119)  
+- Create CODE_OF_CONDUCT.md [#120](https://github.com/blossom-project/blossom/pull/120)  
+- Unit Testing (ActivationController, StatusController, OmnisearchController, BlossomErrorViewResolver) [#121](https://github.com/blossom-project/blossom/pull/121)  
+- HikariCP-java6 exclusion [#122](https://github.com/blossom-project/blossom/pull/122)  
+- Add functionalities to the article module [#123](https://github.com/blossom-project/blossom/pull/123)  
+- Unit Testing [#126](https://github.com/blossom-project/blossom/pull/126)  
+- Simple changes to article module [#127](https://github.com/blossom-project/blossom/pull/127)  
+- Cleaning of Unit Testing  [#128](https://github.com/blossom-project/blossom/pull/128)  
+- correction: title and icon on article create page [#129](https://github.com/blossom-project/blossom/pull/129)  
+- Bad performances of messagesource if launched from jar [#13](https://github.com/blossom-project/blossom/issues/13)    *bug*  *enhancement*  *performance*  
+- Quartz configuration [#130](https://github.com/blossom-project/blossom/issues/130)  
+- GenericCrudServiceImpl + GenericReadOnlyServiceImpl Unit Testing [#131](https://github.com/blossom-project/blossom/pull/131)  
+- Home page and login personalisation [#132](https://github.com/blossom-project/blossom/issues/132)  
+- Fix Issue : Generator conflit message properties file [#133](https://github.com/blossom-project/blossom/pull/133)  
+- RestrictedSessionLocaleResolver + MenuItemImpl + MenuInterceptor + FileController Unit Testing [#134](https://github.com/blossom-project/blossom/pull/134)  
+- Creation of a customized insert link plugin for summernote [#135](https://github.com/blossom-project/blossom/pull/135)  
+- Theme configuration using Scss [#136](https://github.com/blossom-project/blossom/issues/136)  
+- correction: text input in module article [#137](https://github.com/blossom-project/blossom/pull/137)  
+- Manage message source file name and overwritting of them [#22](https://github.com/blossom-project/blossom/issues/22)    *bug*  *enhancement*  
+- Add system menu for liquibase actuator endpoint [#40](https://github.com/blossom-project/blossom/issues/40)  
+- Implements Blossom REST API [#41](https://github.com/blossom-project/blossom/issues/41)    *enhancement*  
+- Secure Blossom REST API [#42](https://github.com/blossom-project/blossom/issues/42)    *enhancement*  
+- Upgrade to Spring-Boot 2.0.0 [#45](https://github.com/blossom-project/blossom/issues/45)    *dependency*  *enhancement*  
+- Cleaning and styling of the project Initializr [#47](https://github.com/blossom-project/blossom/issues/47)    *enhancement*  
+- Activation mail [#53](https://github.com/blossom-project/blossom/pull/53)  
+- Enabling attached files for emails [#54](https://github.com/blossom-project/blossom/pull/54)  
+- Adding the possibility to initialize project as war deployment [#56](https://github.com/blossom-project/blossom/pull/56)  
+- External monitoring [#57](https://github.com/blossom-project/blossom/issues/57)  
+- Protect brute-force attemps on BO users [#58](https://github.com/blossom-project/blossom/issues/58)  
+-  Bootsrap js after jquery-ui js for tooltip conflict  [#59](https://github.com/blossom-project/blossom/pull/59)  
+- Cache improvement [#60](https://github.com/blossom-project/blossom/pull/60)  
+- Add run job on application start doc &amp; minor doc changes [#64](https://github.com/blossom-project/blossom/pull/64)  
+- Blossom 404 overriding [#65](https://github.com/blossom-project/blossom/issues/65)  
+- Login / Forgot your password - Default language [#66](https://github.com/blossom-project/blossom/issues/66)  
+- Design search bar  [#67](https://github.com/blossom-project/blossom/issues/67)  
+- Wrong password + wrong identifier [#68](https://github.com/blossom-project/blossom/issues/68)  
+- Heading title [#69](https://github.com/blossom-project/blossom/issues/69)  
+- French translation [#70](https://github.com/blossom-project/blossom/issues/70)  
+- Scheduler information &quot;forgets&quot; executions [#71](https://github.com/blossom-project/blossom/issues/71)  
+- Crypto module [#72](https://github.com/blossom-project/blossom/pull/72)  
+- French translation [#73](https://github.com/blossom-project/blossom/issues/73)  
+- Groups with the same name [#74](https://github.com/blossom-project/blossom/issues/74)  
+- Menu - I can&#39;t see anything [#75](https://github.com/blossom-project/blossom/issues/75)  
+- Fix TriggerHistory loading from DB [#76](https://github.com/blossom-project/blossom/pull/76)  
+- Fix reset password sending to activation link instead of change_password link [#77](https://github.com/blossom-project/blossom/pull/77)  
+- User/roles association save [#78](https://github.com/blossom-project/blossom/issues/78)  
+- Remove double reset password token submit [#79](https://github.com/blossom-project/blossom/pull/79)  
+- Entity deletion [#80](https://github.com/blossom-project/blossom/issues/80)  
+- Action token dates &amp; activation/password reset tokens invalidation [#81](https://github.com/blossom-project/blossom/pull/81)  
+- Add source &amp; javadoc jars when packaging [#82](https://github.com/blossom-project/blossom/pull/82)  
+- Change version [#83](https://github.com/blossom-project/blossom/pull/83)  
+- Ajout de la génération du controlleur [#84](https://github.com/blossom-project/blossom/pull/84)  
+- Set the not blank param in EntityField [#85](https://github.com/blossom-project/blossom/pull/85)  
+- External monitoring: filtering and extra information [#87](https://github.com/blossom-project/blossom/issues/87)  
+- Disabling default account causes NullPointerException on login fail [#89](https://github.com/blossom-project/blossom/issues/89)  
+- Role privilege management [#90](https://github.com/blossom-project/blossom/issues/90)  
+- Liquibase changelogs [#91](https://github.com/blossom-project/blossom/pull/91)  
+- Add kotlin source language for project initializr [#92](https://github.com/blossom-project/blossom/pull/92)  
+- Upgrade boot 2.0.0 [#93](https://github.com/blossom-project/blossom/pull/93)  
+- Renaming all packages [#94](https://github.com/blossom-project/blossom/pull/94)  
+- Password restrictions on account création [#95](https://github.com/blossom-project/blossom/issues/95)    *enhancement*  
+- Override properties values [#96](https://github.com/blossom-project/blossom/issues/96)    *enhancement*  
+- Regression (?) HTML in title [#97](https://github.com/blossom-project/blossom/issues/97)    *bug*  
+- &quot;404 not found&quot; on item where I can click [#98](https://github.com/blossom-project/blossom/issues/98)    *enhancement*  
+- Disconnect doesn&#39;t properly redirect to login. [#99](https://github.com/blossom-project/blossom/issues/99)  
+-  utf-8  
+
+### No issue
+- Prepare release
+- TravisCI correction
+- Prepare release
+- Prepare release
+- Travis deploy
+- Correction
+- Upgrade to Spring-Boot 2.0.1.RELEASE
+- New favicon
+- Add logo to blossom
+- Customize SchedulerFactoryBean to add custom TriggerListener
+- Using spring-boot-starter-quartz instead of custom built
+- Evict all cache on multiple updates
+- Update README.md
+- Fix Dashboard Autoconfiguration
+- Upgrade to SpringBoot 2.0.0.RC2
+- Package renaming (again !)
+- Change JIRA password
+- test travis
+- Linked Hashset for liquibase scripts ordering
+- Pom correction
+- Test
+- Removing pseudo-integration test project
+- Test
+- Pom correction
+- Pom correction
+- Pom correction
+- Code signing for maven central
+- Code signing for maven central
+- Code signing for maven central
+- Signed-off-by: Maël Gargadennec <mael.gargadennec@gmail.com>
+- Signed-off-by: Maël Gargadennec <mael.gargadennec@gmail.com>
+- test
+- Make shell script executable
+- Make shell script executable
+- Make shell script executable
+- Test
+- Continuous deployment
+- Renaming all packages
+- Removing samples, added into their own repository (blossom-project/blossom-samples)
+- Default Avatar fixed
+- Moving the initializr into it's own repository
+- Travis
+- Travis correction
+- Autoconfiguration and examples
+- Autoconfiguration correction
+- Documentation improvement
+- Error on project without interface
+- Initializr correction on POST
+- Don't fail on principal different than CurrentUser class
+- Change version
+- Unit test correction
+- Unit test correction
+- unit tests
+- Unit tests
+- Change autoconfiguration of default cache configuration
+- Upgrade Jacoco
+- Corrections on generated @Configuration
+- Added bigdecimal and float columns
+- Removing soap client from sample
+- Manage multiple field types in generator
+- Generator builder mecanism (instead of runtime System.in)
+- Url encoding of stateless secret token service's generated tokens
+- Notification + history of triggers executions in job detail
+- Debugging logs
+- Credit author  when credit is due
+- Cryptography autoconfiguration and cleanup
+- Unit tests
+- Unit tests for daos
+- Unit tests for daos
+- Unit tests
+- Unit tests for daos
+- adding unit tests dependencies to modules
+- Unit test for web ui
+- Unit tests
+- Unit tests
+- Unit tests
+- Unit tests
+- Correct after_success test coverage build
+- Unit tests on MenuItemBuilder
+- Update README.md
+- Javadoc + Unit testing + Coveralls/JaCoCo integration in travisci build
+- Added javadoc
+- Override the configuration of date format for all IndexationEngines  (WRITE_DATE_AS_TIMESTAMP should always be true)
+- Override the configuration of date format for all IndexationEngines  (WRITE_DATE_AS_TIMESTAMP should always be true)
+- Avatar content type detection (firefox doesn't like image/* type)
+- FileManager Rest API + tests
+- Added privileges to controllers
+- Refactoring of Controllers + Rest API + tests
+- Related-entity forced deletion before main entity is deleted
+- Scheduler manual execution
+- Blossom image to readme
+- Removing jrebel-jar
+- Major refactoring of SearchEngine and IndexationEngine and Omnisearch page !
+- Major refactoring of SearchEngine and IndexationEngine and Omnisearch page !
+- Major refactoring of SearchEngine and IndexationEngine and Omnisearch page !
+- Major refactoring of SearchEngine and IndexationEngine and Omnisearch page !
+- Major refactoring of SearchEngine and IndexationEngine and Omnisearch page !
+- Major refactoring of SearchEngine and IndexationEngine and Omnisearch page !
+- Changing import for Preconditions
+- Bringing unit test coverage of bo-user-core to 89%
+- UserServiceImpl, testing the constructor
+- UserServiceImpl fully tested + moving some badly placed unit tests
+- Debut TU UserService
+- Update README.md
+- Update .travis.yml
+- Update .travis.yml
+- Update README.md
+- Update README.md
+- Change packages names to fr.blossom instead of fr.mgargadennec.blossom
+- Change packages names to fr.blossom instead of fr.mgargadennec.blossom
+- Activate account Mail Template
+- Mailsender configuration
+- Two objects with null ids are not equals
+- Documentation : Elasticsearch
+- Quartz init script with Liquibase for multiple databases types (h2, mysql, oracle, postgresql, hsqldb)
+- Add generated-sources to the maven resources folders
+- Revert: Fix blossom-module-filemanager compilation
+- Add blossom banner
+- Changing blob types to longblob in liquibase scripts
+- Fix blossom-module-filemanager compilation
+- Add mandatory db changelog to all samples
+- Adding specification pattern utilitary classes
+- Documentation + refactoring of loggers management screen
+- Ordering of ES Trace Repository
+- Update index.md
+- Update index.md
+- Update README.md
+- Restraint Controller advices to BlossomControllers
+- Added Camunda as a Business Process Manager engine
+- Create LICENSE
+- Update index.md
+- Update index.md
+- Update index.md
+- Set theme jekyll-theme-tactile
+- Create index.md
+- Page reseted when search is executed (to prevent empty page of results)
+- Renaming Modification dates
+- Ignore error or missing generated liquibase changelog
+- Generate changelog file with module generator and use it in generated project
+- Liquibase problem when in jar embedded application + initializr update to add the master changelog
+- Liquibase usage instead of Hibernate generate ddl
+- Pom updates and formatting
+- Code coverage
+- Code coverage
+- Duplicate dependency
+- Module generator (resources)
+- Module generator (resources)
+- Module Generator
+- MailSender configuration
+- Adding system user sessions management
+- Renaming file-manager to filemanager module
+- Article module (ultra basic :-) )
+- Dependencies correction for associations
+- Privileges in effect on interfaces
+- Global feature enabling
+- Refactoring of privileges
+- NPE on freemarker
+- Empty date correction
+- Null taken into account
+- Association management User/Role/Group
+- Avatar update
+- Tabs refactoring
+- Parametrized version of the Default Account (system by default)
+- Refacto nom variable
+- Correction bouton cancel
+- Correction email
+- Correction creation
+- Correction déclaration fichier de properties
+- Correction freemarker usergroups
+- Signed-off-by: Maël Gargadennec <mael.gargadennec@gmail.com>
+- Global Exception Handling
+- Transactional event listeners
+- Associations user/roles user/groups
+- Association of group or role to user in the tab
+- Uniformisation
+- User with tabs of groups and roles
+- Correction sur choix enabling module
+- Groups CRUD
+- Role, formattage
+- Correction coquille
+- CRUD for Roles
+- Possibilite de disable un module
+- Table responsive
+- Forgotten password cancellation
+- Indexation event handler
+- Indexation event handler
+- User creation and reset workflow
+- Unit test correction : unused unit test removal
+- UserBuilder correction : add Locale
+- Pull
+- Integration test
+- User creation flow
+- Account activation
+- Multiple features around users
+- pom.xml versions update and project generator started
+- User + dashboard evolution
+- Avatar image
+- Page title sizing
+- Menu Opening on page load (configurable on @Controllers with @OpenedMenu
+- scheduler standby mode and triggers display
+- i18n improvements and configuration
+- i18n improvements and configuration
+- File manager
+- Refactor - Extract functions in dedicated method
+- File manager
+- File manager
+- Integration tests : Users module
+- filemanager
+- LastConnectionUpdateAuthenticationSuccessHandler : defining default url.
+- Integration test correction
+- Integration testing : login. Fail on LOG_002 because user inactivation doesn't seems to be implemented
+- Using user initialized by dataset generator in first integration test
+- Correction
+- Integration test on login page with system user
+- File manager
+- Tag cloud
+- Index mappings/settings
+- Dashboard charts
+- Dashboard charts
+- Slack notification
+- Dashboard requests
+- Dashboard requests
+- Tracking code coverage
+- Tracking code coverage with JaCoCo
+- Traces in ES
+- Tracking code coverage with JaCoCo
+- Unit testing on UserDaoImpl class
+- Traces in ES
+- Elasticsearch display index and index http traces
+- loggers
+- [TU] Couverture de CurrentUserDetailsServiceImpl
+- Code coverage
+- Cobertura
+- Cobertura
+- Cache manager
+- Cache manager
+- merge
+- Caches
+- loggers
+- Dashboard
+- scheduler
+- Scheduler interface
+- Added Quartz Scheduler
+- Added Quartz Scheduler
+- Added Quartz Scheduler
+- Indexation engines scheduling
+- Associations user role
+- Associations user role
+- Association user group
+- Association user group
+- Association user group
+- commit
+- Update README.md
+- Inspinia usage
+- Inspinia usage
+- Blossom v2
+- Cleanup
+- Signed-off-by: Maël Gargadennec <mael.gargadennec@gmail.com>
+- Signed-off-by: Maël Gargadennec <mael.gargadennec@gmail.com>
+- Build with JDK 8
+- Signed-off-by: Maël Gargadennec <mael.gargadennec@gmail.com>
+- Signed-off-by: Maël Gargadennec <mael.gargadennec@gmail.com>
+- TravisCI
+
+

--- a/changelog.mustache
+++ b/changelog.mustache
@@ -1,0 +1,24 @@
+# Changelog
+
+{{#tags}}
+## {{name}}
+ {{#issues}}
+  {{#hasIssue}}
+   {{#hasLink}}
+- {{title}} [{{issue}}]({{link}}) {{#hasIssueType}} *{{issueType}}* {{/hasIssueType}} {{#hasLabels}} {{#labels}} *{{.}}* {{/labels}} {{/hasLabels}}
+   {{/hasLink}}
+   {{^hasLink}}
+- {{title}} {{issue}} {{#hasIssueType}} *{{issueType}}* {{/hasIssueType}} {{#hasLabels}} {{#labels}} *{{.}}* {{/labels}} {{/hasLabels}}
+   {{/hasLink}}
+  {{/hasIssue}}
+  {{^hasIssue}}
+
+### {{name}}
+    {{#commits}}
+- {{{messageTitle}}}
+    {{/commits}}
+  {{/hasIssue}}
+ {{/issues}}
+
+
+{{/tags}}

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,14 @@
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>se.bjurr.gitchangelog</groupId>
+        <artifactId>git-changelog-maven-plugin</artifactId>
+        <version>1.54</version>
+        <configuration>
+          <file>CHANGELOG.md</file>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Add a maven plugin to allow automated changelog generation with `mvn git-changelog-maven-plugin:git-changelog`

I'm still not a fan of putting every commit that did not go through an issue / a pull request "as is" in the changelog. Should we use the plugin to generate a first version of the changelog then manually update it? Or start making sure everything goes through a PR ?