### PR TITLE
LongFieldBuilder JDBC type "long" badly translate to mediumtext on MySQL

### DIFF
--- a/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/LongFieldBuilder.java
+++ b/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/LongFieldBuilder.java
@@ -6,7 +6,7 @@ import com.blossomproject.generator.configuration.model.impl.DefaultField;
 public class LongFieldBuilder extends FieldBuilder<LongFieldBuilder> {
 
   LongFieldBuilder(FieldsBuilder parent, String name) {
-    super(parent, name, Long.class, "long");
+    super(parent, name, Long.class, "bigint");
   }
 
   @Override


### PR DESCRIPTION
change the jdbc type to "bigint" in the LongFieldBuilder