### PR TITLE
If there is no page, remove pagiation instead of displaying 1-0 of 0

### DIFF
--- a/blossom-ui/blossom-ui-web/src/main/resources/templates/blossom/utils/pagination.ftl
+++ b/blossom-ui/blossom-ui-web/src/main/resources/templates/blossom/utils/pagination.ftl
@@ -66,12 +66,14 @@
 
 
 <#macro renderPosition page label>
-    <#assign index = (page.number * page.size) >
-    <#assign indexMin = index + 1>
-    <#assign indexMax = index + page.numberOfElements>
     <#assign totalElements = page.totalElements>
-    <#assign paginationArgs = [index + 1, index + page.numberOfElements, page.totalElements]>
+    <#if totalElements gt 0>
+        <#assign index = (page.number * page.size) >
+        <#assign indexMin = index + 1>
+        <#assign indexMax = index + page.numberOfElements>
+        <#assign paginationArgs = [index + 1, index + page.numberOfElements, page.totalElements]>
 <small class="text-muted inline m-t-sm m-b-sm"><@spring.messageText label label /> <@spring.messageText "list.pagination.detail.label" paginationArgs /></small>
+    </#if>
 </#macro>
 
 


### PR DESCRIPTION
Actually, the pager display "page 1-0 of 0" if there is nothing to display.  
This simply remove the pagination if there is no result.