### PR TITLE
fix date filter initialization

### DIFF
--- a/blossom-ui/blossom-ui-web/src/main/resources/templates/blossom/utils/table.ftl
+++ b/blossom-ui/blossom-ui-web/src/main/resources/templates/blossom/utils/table.ftl
@@ -170,6 +170,12 @@
 
     var dateFacets = $(".table-search-filter-dates");
     dateFacets.each(function (i) {
+      if($(this).data('startDate') === undefined) {
+          $(this).data("startDate", "");
+      }
+      if($(this).data('endDate') === undefined) {
+          $(this).data("endDate", "");
+      }
       filters.push($(this).data("path") + '//' + $(this).data("type") + '//' + $(this).data('startDate') + '/' + $(this).data('endDate'));
     });
     return $.updateQueryStringParameter(location, 'filters', filters.join(";"));


### PR DESCRIPTION
When you apply a search with an empty date filter you had a "default error page" because **startDate** and **endDate** were not initialized.