### PR TITLE
Do not throw any exception in GlobalTriggerListener

### DIFF
--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
@@ -3,12 +3,14 @@ package com.blossomproject.core.scheduler.history;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.quartz.JobKey;
 import org.quartz.TriggerKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.transaction.annotation.Transactional;
 
 public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
 
@@ -73,6 +75,7 @@ public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
   }
 
   @Override
+  @Transactional
   public void create(TriggerHistory triggerHistory) {
     Timestamp now = new Timestamp(System.currentTimeMillis());
     jdbcTemplate.update(
@@ -94,6 +97,7 @@ public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
   }
 
   @Override
+  @Transactional
   public void updateEndDate(String fireInstanceId) {
     jdbcTemplate.update(
       "update " + TABLE_NAME + " set end_time=? where fire_instance_id=?",

--- a/blossom-core/blossom-core-scheduler/src/test/java/com/blossomproject/core/scheduler/listener/GlobalTriggerListenerTest.java
+++ b/blossom-core/blossom-core-scheduler/src/test/java/com/blossomproject/core/scheduler/listener/GlobalTriggerListenerTest.java
@@ -4,12 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.blossomproject.core.scheduler.history.TriggerHistory;
 import com.blossomproject.core.scheduler.history.TriggerHistoryDao;
@@ -94,6 +89,41 @@ public class GlobalTriggerListenerTest {
     when(context.getFireInstanceId()).thenReturn("fireInstanceId");
 
     CompletedExecutionInstruction instruction = CompletedExecutionInstruction.SET_TRIGGER_COMPLETE;
+
+    this.listener.triggerComplete(trigger, context, instruction);
+
+    verify(this.triggerHistoryDao, times(1)).updateEndDate(eq(context.getFireInstanceId()));
+  }
+
+  @Test
+  public void should_not_throw_any_exception_on_trigger_fired() {
+    Trigger trigger = mock(Trigger.class);
+    when(trigger.getKey()).thenReturn(new TriggerKey("trigger","group"));
+    when(trigger.getJobKey()).thenReturn(new JobKey("job","group"));
+
+    JobExecutionContext context = mock(JobExecutionContext.class);
+    when(context.getFireInstanceId()).thenReturn("fireInstanceId");
+    when(context.getFireTime()).thenReturn(new Date(System.currentTimeMillis()));
+
+    doThrow(new RuntimeException()).when(this.triggerHistoryDao).create(any());
+
+    this.listener.triggerFired(trigger, context);
+
+    verify(this.triggerHistoryDao, times(1)).create(any(TriggerHistory.class));
+  }
+
+  @Test
+  public void should_not_throw_any_exception_on_trigger_completed() throws Exception{
+    Trigger trigger = mock(Trigger.class);
+    when(trigger.getKey()).thenReturn(new TriggerKey("trigger","group"));
+    when(trigger.getJobKey()).thenReturn(new JobKey("job","group"));
+
+    JobExecutionContext context = mock(JobExecutionContext.class);
+    when(context.getFireInstanceId()).thenReturn("fireInstanceId");
+
+    CompletedExecutionInstruction instruction = CompletedExecutionInstruction.SET_TRIGGER_COMPLETE;
+
+    doThrow(new RuntimeException()).when(this.triggerHistoryDao).updateEndDate(any());
 
     this.listener.triggerComplete(trigger, context, instruction);
 


### PR DESCRIPTION
Fix #181  
Any exception thrown during Quartz's listener trigger breaks the job for which the listener was called.

In the issue's example, the exception was `org.springframework.transaction.CannotCreateTransactionException`, caused by having `@Transactional` on the listener's method directly. I have moved the transactional part to the DAO directly, and wrapped the DAO call in a try/catch intercepting any exception to prevent the scheduler from breaking.