### PR TITLE
Module generator mysql

### DIFF
--- a/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/BlobFieldBuilder.java
+++ b/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/BlobFieldBuilder.java
@@ -6,7 +6,7 @@ import com.blossomproject.generator.configuration.model.impl.BlobField;
 public class BlobFieldBuilder extends FieldBuilder<BlobFieldBuilder> {
 
   BlobFieldBuilder(FieldsBuilder parent, String name) {
-    super(parent, name, Byte[].class, "blob");
+    super(parent, name, Byte[].class, "longblob");
   }
 
   @Override

--- a/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/EnumFieldBuilder.java
+++ b/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/EnumFieldBuilder.java
@@ -1,7 +1,6 @@
 package com.blossomproject.generator.configuration;
 
 import com.blossomproject.generator.configuration.model.Field;
-import com.blossomproject.generator.configuration.model.impl.DefaultField;
 import com.blossomproject.generator.configuration.model.impl.EnumField;
 
 public class EnumFieldBuilder extends FieldBuilder<EnumFieldBuilder> {
@@ -10,13 +9,21 @@ public class EnumFieldBuilder extends FieldBuilder<EnumFieldBuilder> {
     private final Class<? extends Enum> enumClass;
 
     EnumFieldBuilder(FieldsBuilder parent, String name, Class<? extends Enum> enumClass) {
-        super(parent, name, enumClass, "varchar");
+        super(parent, name, enumClass, "varchar(" + maxSize(enumClass) + ")");
         this.enumClass = enumClass;
     }
 
     @Override
     Field build() {
         return new EnumField(name, columnName, className, jdbcType, required, updatable, nullable,
-                defaultValue, searchable, enumClass);
+                defaultValue, searchable, maxSize(enumClass));
+    }
+
+    private static int maxSize(Class<? extends Enum> enumClass) {
+        int maxSize = 0;
+        for (Enum enumValue : enumClass.getEnumConstants()) {
+            maxSize = Math.max(maxSize, enumValue.name().length());
+        }
+        return maxSize;
     }
 }

--- a/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/model/impl/EnumField.java
+++ b/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/configuration/model/impl/EnumField.java
@@ -1,11 +1,9 @@
 package com.blossomproject.generator.configuration.model.impl;
 
-public class EnumField extends  DefaultField {
+public class EnumField extends StringField {
 
-    private final Class<? extends Enum> enumClass;
+  public EnumField(String name, String columnName, Class<?> className, String jdbcType, boolean required, boolean updatable, boolean nullable, String defaultValue, boolean searchable, int maxLength) {
+    super(name, columnName, className, jdbcType, required, updatable, nullable, defaultValue, searchable, true, maxLength, false);
+  }
 
-    public EnumField(String name, String columnName, Class<?> className, String jdbcType, boolean required, boolean updatable, boolean nullable, String defaultValue, boolean searchable, Class<? extends Enum> enumClass) {
-        super(name, columnName, className, jdbcType, required, updatable, nullable, defaultValue, searchable);
-        this.enumClass = enumClass;
-    }
 }

--- a/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/utils/GeneratorUtils.java
+++ b/blossom-tools/blossom-tools-simple-module-generator/src/main/java/com/blossomproject/generator/utils/GeneratorUtils.java
@@ -4,6 +4,7 @@ import com.blossomproject.generator.configuration.model.Field;
 import com.blossomproject.generator.configuration.model.Settings;
 import com.blossomproject.generator.configuration.model.StringField;
 import com.blossomproject.generator.configuration.model.TemporalField;
+import com.blossomproject.generator.configuration.model.impl.BlobField;
 import com.blossomproject.generator.configuration.model.impl.EnumField;
 import com.helger.jcodemodel.*;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -204,6 +205,9 @@ public class GeneratorUtils {
     }
     else if(field instanceof StringField && ((StringField) field).isLob()) {
       formField = generateFormFieldTextarea(field, formFieldTemplateTextarea);
+    }
+    else if (field instanceof BlobField) {
+      return "";
     }
     else {
       String htmlType = getHtmlType(field);


### PR DESCRIPTION
Fix #165 and #167 :

- Use the longest enum name for varchar column size
- Use "longblob" as liquibase type for blobs, validates fine on H2 and MySQL databases
- Do not show "blob" fields in the generated entity view