### PR TITLE
Better security default for system account

### DIFF
--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/DefaultAccountProperties.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/DefaultAccountProperties.java
@@ -5,15 +5,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "blossom.security.default.account")
 public class DefaultAccountProperties {
 
-    private boolean enabled;
+    private Boolean enabled;
     private String identifier;
     private String password;
 
-    public boolean isEnabled() {
+    public Boolean isEnabled() {
         return enabled;
     }
 
-    public void setEnabled(boolean enabled) {
+    public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
     }
 

--- a/blossom-autoconfigure/src/main/resources/security.properties
+++ b/blossom-autoconfigure/src/main/resources/security.properties
@@ -1,3 +1,2 @@
-blossom.security.default.account.enabled=true
 blossom.security.default.account.identifier=system
-blossom.security.default.account.password=system
+blossom.security.default.account.password=${random.value}

--- a/blossom-core/blossom-core-association-user-role/src/main/java/com/blossomproject/core/association_user_role/AssociationUserRoleDao.java
+++ b/blossom-core/blossom-core-association-user-role/src/main/java/com/blossomproject/core/association_user_role/AssociationUserRoleDao.java
@@ -1,12 +1,17 @@
 package com.blossomproject.core.association_user_role;
 
 import com.blossomproject.core.common.dao.AssociationDao;
+import com.blossomproject.core.common.utils.privilege.Privilege;
 import com.blossomproject.core.role.Role;
 import com.blossomproject.core.user.User;
+
+import java.util.List;
 
 /**
  * Created by Maël Gargadennnec on 03/05/2017.
  */
 public interface AssociationUserRoleDao extends AssociationDao<User, Role, AssociationUserRole> {
+
+  boolean getUserExistsByPrivilege(List<Privilege> privilege);
 
 }

--- a/blossom-core/blossom-core-association-user-role/src/main/java/com/blossomproject/core/association_user_role/AssociationUserRoleDaoImpl.java
+++ b/blossom-core/blossom-core-association-user-role/src/main/java/com/blossomproject/core/association_user_role/AssociationUserRoleDaoImpl.java
@@ -1,19 +1,37 @@
 package com.blossomproject.core.association_user_role;
 
 import com.blossomproject.core.common.dao.GenericAssociationDaoImpl;
+import com.blossomproject.core.common.utils.privilege.Privilege;
 import com.blossomproject.core.role.Role;
 import com.blossomproject.core.user.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import java.util.List;
 
 /**
  * Created by Maël Gargadennnec on 03/05/2017.
  */
 public class AssociationUserRoleDaoImpl extends GenericAssociationDaoImpl<User, Role, AssociationUserRole> implements AssociationUserRoleDao {
-    public AssociationUserRoleDaoImpl(AssociationUserRoleRepository repository) {
-        super(repository);
-    }
 
-    @Override
-    protected AssociationUserRole create() {
-        return new AssociationUserRole();
-    }
+  private final AssociationUserRoleRepository repository;
+
+  public AssociationUserRoleDaoImpl(AssociationUserRoleRepository repository) {
+    super(repository);
+    this.repository = repository;
+  }
+
+  @Override
+  protected AssociationUserRole create() {
+    return new AssociationUserRole();
+  }
+
+  @Override
+  public boolean getUserExistsByPrivilege(List<Privilege> privileges) {
+    return repository.exists(
+      privileges
+        .stream()
+        .map(privilege -> QAssociationUserRole.associationUserRole.b.privileges.contains(privilege.privilege()))
+        .reduce(QAssociationUserRole.associationUserRole.a.activated.isTrue(), BooleanExpression::and)
+    );
+  }
 }

--- a/blossom-core/blossom-core-association-user-role/src/test/java/com/blossomproject/core/association_user_role/AssociationUserRoleDaoImplIntegrationTest.java
+++ b/blossom-core/blossom-core-association-user-role/src/test/java/com/blossomproject/core/association_user_role/AssociationUserRoleDaoImplIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.blossomproject.core.association_user_role;
+
+
+import com.blossomproject.core.common.utils.privilege.SimplePrivilege;
+import com.blossomproject.core.role.Role;
+import com.blossomproject.core.role.RoleDao;
+import com.blossomproject.core.user.User;
+import com.blossomproject.core.user.UserDao;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.transaction.Transactional;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {DaoTestContext.class})
+@Transactional
+public class AssociationUserRoleDaoImplIntegrationTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Autowired
+  private UserDao userDao;
+
+  @Autowired
+  private RoleDao roleDao;
+
+  @Autowired
+  private AssociationUserRoleDao associationUserRoleDao;
+
+  @Test
+  public void should_not_find_when_no_user() {
+    assertFalse(associationUserRoleDao.getUserExistsByPrivilege(Collections.emptyList()));
+  }
+
+  @Test
+  public void should_not_find_when_user_with_no_role() {
+    createUser(true);
+
+    assertFalse(associationUserRoleDao.getUserExistsByPrivilege(Collections.emptyList()));
+  }
+
+  @Test
+  public void should_not_find_when_user_with_role_no_privileges() {
+    User user = createUser(true);
+    Role role = createRole(Collections.emptyList());
+    createAssociationUserRole(user, role);
+
+    assertFalse(associationUserRoleDao.getUserExistsByPrivilege(Collections.singletonList(new SimplePrivilege("pri:vi:lege"))));
+  }
+
+  @Test
+  public void should_not_find_when_user_with_role_not_activated() {
+    User user = createUser(false);
+    Role role = createRole(Collections.singletonList("pri:vi:lege"));
+    createAssociationUserRole(user, role);
+
+    assertFalse(associationUserRoleDao.getUserExistsByPrivilege(Collections.singletonList(new SimplePrivilege("pri:vi:lege"))));
+  }
+
+  @Test
+  public void should_find_when_user_with_role_and_all_privileges() {
+    User user = createUser(true);
+    Role role = createRole(Arrays.asList("pri:vi:lege", "lege:pri:vi", "vi:lege:pri"));
+    createAssociationUserRole(user, role);
+
+    assertTrue(associationUserRoleDao.getUserExistsByPrivilege(
+      Arrays.asList(new SimplePrivilege("pri:vi:lege"), new SimplePrivilege("lege:pri:vi"), new SimplePrivilege("vi:lege:pri"))));
+  }
+
+  private User createUser(boolean activated) {
+    User user = new User();
+    user.setIdentifier("b");
+    user.setPasswordHash("l");
+    user.setActivated(activated);
+    user.setFirstname("o");
+    user.setLastname("s");
+    user.setEmail("s");
+    user.setLocale(Locale.ENGLISH);
+    user.setCreationUser("o");
+    user.setModificationUser("m");
+    return userDao.create(user);
+  }
+
+  private Role createRole(List<String> privileges) {
+    Role role = new Role();
+    role.setName("role" + (privileges.isEmpty() ? "" : privileges.get(0)));
+    role.setDescription("description");
+    role.setPrivileges(privileges);
+    return roleDao.create(role);
+  }
+
+  private AssociationUserRole createAssociationUserRole(User user, Role role) {
+    return associationUserRoleDao.associate(user, role);
+  }
+
+}

--- a/blossom-core/blossom-core-association-user-role/src/test/java/com/blossomproject/core/association_user_role/DaoTestContext.java
+++ b/blossom-core/blossom-core-association-user-role/src/test/java/com/blossomproject/core/association_user_role/DaoTestContext.java
@@ -1,0 +1,43 @@
+package com.blossomproject.core.association_user_role;
+
+import com.blossomproject.core.role.Role;
+import com.blossomproject.core.role.RoleDao;
+import com.blossomproject.core.role.RoleDaoImpl;
+import com.blossomproject.core.role.RoleRepository;
+import com.blossomproject.core.user.User;
+import com.blossomproject.core.user.UserDao;
+import com.blossomproject.core.user.UserDaoImpl;
+import com.blossomproject.core.user.UserRepository;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * Created by rlejolivet on 2018-08-08
+ */
+@Configuration
+@EnableJpaRepositories(basePackageClasses = {UserRepository.class, RoleRepository.class, AssociationUserRoleRepository.class})
+@EntityScan(basePackageClasses = {User.class, Role.class, AssociationUserRole.class})
+@Import({DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
+public class DaoTestContext {
+
+  @Bean
+  public UserDao userDao(UserRepository userRepository) {
+    return new UserDaoImpl(userRepository);
+  }
+
+  @Bean
+  public RoleDao roleDao(RoleRepository roleRepository) {
+    return new RoleDaoImpl(roleRepository);
+  }
+
+  @Bean
+  public AssociationUserRoleDao associationUserRoleDao(AssociationUserRoleRepository repository) {
+    return new AssociationUserRoleDaoImpl(repository);
+  }
+
+}


### PR DESCRIPTION
Fix #179 

- "system" account password is randomized and shown in logs at application startup when it is activated
- Default is not to always activate the "system" account. Instead, it is only activated if there are no actual account created with enough privileges to grant more privileges, that could be used to recover back-office access (at least by granting itself more privileges if needed).

Note that it is possible to override the password and system account activation to recover previous workflow, but it must now be a conscious decision.

Also note that looking for a user with enough privileges to decide if the system account should be enabled will slow down startup somewhat, it is still recommended to explicitly disable system account when not needed.