### PR TITLE
Fix filter for InternetAddress with personnal

### DIFF
--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
@@ -58,12 +58,20 @@ public class MailFilterImpl implements MailFilter {
     private String[] filterMails(Address[] recipients) {
         if (recipients != null) {
             if (this.filters != null && !this.filters.isEmpty()) {
-                return Stream.of(recipients).map(Address::toString).filter(s -> this.filters.stream().anyMatch(s::matches)).toArray(String[]::new);
+                return Stream.of(recipients).map(this::getEmailAdress).filter(s -> this.filters.stream().anyMatch(s::matches)).toArray(String[]::new);
             } else {
-                return Stream.of(recipients).map(Address::toString).toArray(String[]::new);
+                return Stream.of(recipients).map(this::getEmailAdress).toArray(String[]::new);
             }
         } else {
             return null;
+        }
+    }
+
+    private String getEmailAdress(Address recipient) {
+        if (!(recipient instanceof InternetAddress)) {
+            return recipient.toString();
+        } else {
+            return ((InternetAddress) recipient).getAddress();
         }
     }
 

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailFilterImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailFilterImplTest.java
@@ -1,15 +1,6 @@
 package com.blossomproject.core.common.utils.mail;
 
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-
 import com.google.common.collect.Sets;
-import javax.mail.Address;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,83 +9,114 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mail.javamail.MimeMessageHelper;
 
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 
 @RunWith(MockitoJUnitRunner.class)
 public class MailFilterImplTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-    private MailFilter mailFilter;
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  private MailFilter mailFilter;
 
 
-    @Before
-    public void setUp() throws AddressException {
-        this.mailFilter = new MailFilterImpl(Sets.newHashSet(".*@test.com"), new InternetAddress("blossom-project@blossom.com"));
+  @Before
+  public void setUp() throws AddressException {
+    this.mailFilter = new MailFilterImpl(Sets.newHashSet(".*@test.com"), new InternetAddress("Blossom Project <blossom-project@blossom.com>"));
 
-    }
+  }
 
 
-    @Test
-    public void filter_with_cc_bcc() throws Exception {
-        final MimeMessage mimeMessage = mock(MimeMessage.class);
-        final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
-        doReturn(new Address[]{new InternetAddress("test@test.com")}).when(mimeMessage).getRecipients(Message.RecipientType.TO);
-        doReturn(new Address[]{new InternetAddress("filter@filter.com")}).when(mimeMessage).getRecipients(Message.RecipientType.CC);
-        doReturn(new Address[]{new InternetAddress("filter@filter.com")}).when(mimeMessage).getRecipients(Message.RecipientType.BCC);
-        helper.setSubject("subject");
-        helper.setText("htmlContent", true);
-        this.mailFilter.filter(helper);
-    }
+  @Test
+  public void filter_with_cc_bcc() throws Exception {
+    final MimeMessageHelper helper = new MimeMessageHelper(new MimeMessage((Session) null));
+    helper.setTo("test@test.com");
+    helper.setCc("filter@filter.com");
+    helper.setBcc("filter@filter.com");
+    helper.setSubject("subject");
+    helper.setText("htmlContent", true);
+    MimeMessage result = this.mailFilter.filter(helper);
+    assertEquals("test.com matches", 1, result.getRecipients(Message.RecipientType.TO).length);
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.CC));
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.BCC));
+  }
 
-    @Test
-    public void no_filter_cc_bcc() throws Exception {
-        final MimeMessage mimeMessage = mock(MimeMessage.class);
-        final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
-        doReturn(new Address[]{new InternetAddress("test@test.com")}).when(mimeMessage).getRecipients(Message.RecipientType.TO);
-        doReturn(new Address[]{new InternetAddress("test@test.com")}).when(mimeMessage).getRecipients(Message.RecipientType.CC);
-        doReturn(new Address[]{new InternetAddress("test@test.com")}).when(mimeMessage).getRecipients(Message.RecipientType.BCC);
-        helper.setSubject("subject");
-        helper.setText("htmlContent", true);
-        this.mailFilter.filter(helper);
-    }
+  @Test
+  public void no_filter_cc_bcc() throws Exception {
+    final MimeMessageHelper helper = new MimeMessageHelper(new MimeMessage((Session) null));
+    helper.setTo("test@test.com");
+    helper.setCc("test@test.com");
+    helper.setBcc("test@test.com");
+    helper.setSubject("subject");
+    helper.setText("htmlContent", true);
+    MimeMessage result = this.mailFilter.filter(helper);
+    assertEquals("test.com matches", 1, result.getRecipients(Message.RecipientType.TO).length);
+    assertEquals("test.com matches", 1, result.getRecipients(Message.RecipientType.CC).length);
+    assertEquals("test.com matches", 1, result.getRecipients(Message.RecipientType.BCC).length);
+  }
 
-    @Test
-    public void filter_to() throws Exception{
-        thrown.expect(MessagingException.class);
-        final MimeMessage mimeMessage = mock(MimeMessage.class);
-        final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
-        doReturn(new Address[]{new InternetAddress("filter@filter.com")}).when(mimeMessage).getRecipients(Message.RecipientType.TO);
-        doReturn(new Address[]{new InternetAddress("filter@filter.com")}).when(mimeMessage).getRecipients(Message.RecipientType.CC);
-        doReturn(new Address[]{new InternetAddress("filter@filter.com")}).when(mimeMessage).getRecipients(Message.RecipientType.BCC);
-        helper.setSubject("subject");
-        helper.setText("htmlContent", true);
-        this.mailFilter.filter(helper);
-    }
+  @Test
+  public void filter_to() throws Exception {
+    thrown.expect(MessagingException.class);
+    final MimeMessageHelper helper = new MimeMessageHelper(new MimeMessage((Session) null));
+    helper.setTo("filter@filter.com");
+    helper.setCc("filter@filter.com");
+    helper.setBcc("filter@filter.com");
+    helper.setSubject("subject");
+    helper.setText("htmlContent", true);
+    MimeMessage result = this.mailFilter.filter(helper);
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.TO));
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.CC));
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.BCC));
+  }
 
-    @Test
-    public void no_filter() throws Exception{
-        MailFilter mailFilterNoFilter = new MailFilterImpl(null,new InternetAddress("blossom-project@blossom.com"));
-        final MimeMessage mimeMessage = mock(MimeMessage.class);
-        final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
-        doReturn(new Address[]{new InternetAddress("test@test.com")}).when(mimeMessage).getRecipients(Message.RecipientType.TO);
-        doReturn(new Address[]{new InternetAddress("filter@filter.com")}).when(mimeMessage).getRecipients(Message.RecipientType.CC);
-        doReturn(new Address[]{new InternetAddress("filter@filter.com")}).when(mimeMessage).getRecipients(Message.RecipientType.BCC);
-        helper.setSubject("subject");
-        helper.setText("htmlContent", true);
-        mailFilterNoFilter.filter(helper);
-    }
+  @Test
+  public void no_filter() throws Exception {
+    MailFilter mailFilterNoFilter = new MailFilterImpl(null, new InternetAddress("blossom-project@blossom.com"));
+    final MimeMessageHelper helper = new MimeMessageHelper(new MimeMessage((Session) null));
+    helper.setTo("test@test.com");
+    helper.setCc("filter@filter.com");
+    helper.setBcc("filter@filter.com");
+    helper.setSubject("subject");
+    helper.setText("htmlContent", true);
+    MimeMessage result = mailFilterNoFilter.filter(helper);
+    assertEquals("To goes through", 1, result.getRecipients(Message.RecipientType.TO).length);
+    assertEquals("Cc goes through", 1, result.getRecipients(Message.RecipientType.CC).length);
+    assertEquals("Bcc goes through", 1, result.getRecipients(Message.RecipientType.BCC).length);
+  }
 
-    @Test
-    public void no_recipients() throws Exception{
-        thrown.expect(MessagingException.class);
-        final MimeMessage mimeMessage = mock(MimeMessage.class);
-        final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
-        doReturn(null).when(mimeMessage).getRecipients(Message.RecipientType.TO);
-        doReturn(null).when(mimeMessage).getRecipients(Message.RecipientType.CC);
-        doReturn(null).when(mimeMessage).getRecipients(Message.RecipientType.BCC);
-        helper.setSubject("subject");
-        helper.setText("htmlContent", true);
-        this.mailFilter.filter(helper);
-    }
+  @Test
+  public void no_recipients() throws Exception {
+    thrown.expect(MessagingException.class);
+    final MimeMessageHelper helper = new MimeMessageHelper(new MimeMessage((Session) null));
+    helper.setSubject("subject");
+    helper.setText("htmlContent", true);
+    MimeMessage result = this.mailFilter.filter(helper);
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.TO));
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.CC));
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.BCC));
+  }
+
+  @Test
+  public void filter_internet_adress_with_personnal() throws Exception {
+    final MimeMessageHelper helper = new MimeMessageHelper(new MimeMessage((Session) null));
+    helper.setTo("test test <test@test.com>");
+    helper.setCc("filter this <filter@filter.com>");
+    helper.setBcc("filter that <filter@filter.com>");
+    helper.setSubject("subject");
+    helper.setText("htmlContent", true);
+    MimeMessage result = this.mailFilter.filter(helper);
+    assertEquals("test.com matches", 1, result.getRecipients(Message.RecipientType.TO).length);
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.CC));
+    assertNull("filter.com does not match", result.getRecipients(Message.RecipientType.BCC));
+  }
 
 }


### PR DESCRIPTION
Since the switch to using InternetAddresses for emails, previous filter regexes would not work for the same emails (due to not having `>` at the end most of the time).

The filter now only applies to the actual address part, and ignores the personal + formatting of InternetAddress.