### PR TITLE
close #180 : Unconfigured mail use warn logger instead of info

### DIFF
--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
@@ -194,7 +194,7 @@ public class MailSenderImpl implements MailSender {
 
             LOGGER.info("Mail with recipient(s) {} sent.", Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.TO)));
         } else {
-            LOGGER.info(
+            LOGGER.warn(
                     "A mail with recipient(s) '{}' and subject '{}' was not sent because no java mail sender is configured",
                     Arrays.toString(mailTo), mailSubject);
         }

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
@@ -102,7 +102,7 @@ public class NoopMailSenderImpl implements MailSender {
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
     InternetAddress... mailTo) throws Exception {
     if (LOGGER.isInfoEnabled()) {
-      LOGGER.info(
+      LOGGER.warn(
         "A mail with recipient(s) '{}' and subject '{}' was not sent because no java mail sender is configured",
         Arrays.toString(mailTo), mailSubject);
     }


### PR DESCRIPTION
Change log level to warn when javamail is incorrectly or not configured