### PR TITLE
Fix mail loglevel for NoopMailSenderImpl

### DIFF
--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
@@ -1,15 +1,16 @@
 package com.blossomproject.core.common.utils.mail;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.InputStreamSource;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.InputStreamSource;
 
 /**
  * Created by Maël Gargadennnec on 04/05/2017.
@@ -25,7 +26,7 @@ public class NoopMailSenderImpl implements MailSender {
 
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    List<File> attachedFiles, String... mailTo) throws Exception {
+                       List<File> attachedFiles, String... mailTo) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
   }
 
@@ -56,19 +57,19 @@ public class NoopMailSenderImpl implements MailSender {
 
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    String... mailTo) throws Exception {
+                       String... mailTo) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
   }
 
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress... mailTo)
-      throws Exception {
+    throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
   }
 
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-      List<File> attachedFiles, InternetAddress... mailTo) throws Exception {
+                       List<File> attachedFiles, InternetAddress... mailTo) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
   }
 
@@ -100,22 +101,20 @@ public class NoopMailSenderImpl implements MailSender {
 
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    InternetAddress... mailTo) throws Exception {
-    if (LOGGER.isInfoEnabled()) {
-      LOGGER.warn(
-        "A mail with recipient(s) '{}' and subject '{}' was not sent because no java mail sender is configured",
-        Arrays.toString(mailTo), mailSubject);
-    }
+                       InternetAddress... mailTo) throws Exception {
+    LOGGER.warn(
+      "A mail with recipient(s) '{}' and subject '{}' was not sent because no java mail sender is configured",
+      Arrays.toString(mailTo), mailSubject);
   }
 
   private InternetAddress[] convertToInternetAddress(String[] mails) throws AddressException {
-    if(mails == null){
+    if (mails == null) {
       return null;
     }
 
-    int i=0;
+    int i = 0;
     InternetAddress[] addresses = new InternetAddress[mails.length];
-    for(String mail : mails){
+    for (String mail : mails) {
       addresses[i] = new InternetAddress(mail);
     }
 


### PR DESCRIPTION
Remove `LOGGER.isInfoEnabled()` for warn level log