### PR TITLE
MailSender allow BCC-only and multiple recipients

### DIFF
--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
@@ -31,29 +31,19 @@ public class MailFilterImpl implements MailFilter {
   public MimeMessage filter(MimeMessageHelper mimeMessageHelper) throws MessagingException {
     Map<Message.RecipientType, String[]> recipientsFiltered = this.getFilteredRecipients(mimeMessageHelper.getMimeMessage());
 
-    if (recipientsFiltered.get(Message.RecipientType.TO) != null && recipientsFiltered.get(Message.RecipientType.TO).length > 0 ||
-      recipientsFiltered.get(Message.RecipientType.CC) != null && recipientsFiltered.get(Message.RecipientType.CC).length > 0 ||
-      recipientsFiltered.get(Message.RecipientType.BCC) != null && recipientsFiltered.get(Message.RecipientType.BCC).length > 0
+    String[] recipientsTo = recipientsFiltered.get(Message.RecipientType.TO);
+    String[] recipientsCc = recipientsFiltered.get(Message.RecipientType.CC);
+    String[] recipientsBcc = recipientsFiltered.get(Message.RecipientType.BCC);
+
+    if (isRecipientsArrayNotEmpty(recipientsTo) ||
+      isRecipientsArrayNotEmpty(recipientsCc) ||
+      isRecipientsArrayNotEmpty(recipientsBcc)
     ) {
       mimeMessageHelper.setFrom(from);
 
-      if (recipientsFiltered.get(Message.RecipientType.TO) != null && recipientsFiltered.get(Message.RecipientType.TO).length > 0) {
-        mimeMessageHelper.setTo(recipientsFiltered.get(Message.RecipientType.TO));
-      } else {
-        mimeMessageHelper.setTo(new String[0]);
-      }
-
-      if (recipientsFiltered.get(Message.RecipientType.CC) != null && recipientsFiltered.get(Message.RecipientType.CC).length > 0) {
-        mimeMessageHelper.setCc(recipientsFiltered.get(Message.RecipientType.CC));
-      } else {
-        mimeMessageHelper.setCc(new String[0]);
-      }
-
-      if (recipientsFiltered.get(Message.RecipientType.BCC) != null && recipientsFiltered.get(Message.RecipientType.BCC).length > 0) {
-        mimeMessageHelper.setBcc(recipientsFiltered.get(Message.RecipientType.BCC));
-      } else {
-        mimeMessageHelper.setBcc(new String[0]);
-      }
+      mimeMessageHelper.setTo(isRecipientsArrayNotEmpty(recipientsTo) ? recipientsTo : new String[0]);
+      mimeMessageHelper.setCc(isRecipientsArrayNotEmpty(recipientsTo) ? recipientsCc : new String[0]);
+      mimeMessageHelper.setBcc(isRecipientsArrayNotEmpty(recipientsTo) ? recipientsBcc : new String[0]);
 
       return mimeMessageHelper.getMimeMessage();
     } else {
@@ -94,6 +84,10 @@ public class MailFilterImpl implements MailFilter {
       result.put(recipientType, filterMails(mimeMessage.getRecipients(recipientType)));
     }
     return result;
+  }
+
+  private boolean isRecipientsArrayNotEmpty(String[] recipients) {
+    return recipients != null && recipients.length > 0;
   }
 
 }

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
@@ -1,90 +1,100 @@
 package com.blossomproject.core.common.utils.mail;
 
 import com.google.common.base.Preconditions;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
 import javax.mail.Address;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 public class MailFilterImpl implements MailFilter {
-    private final static Logger LOGGER = LoggerFactory.getLogger(MailFilterImpl.class);
-    private final Set<String> filters;
-    private final InternetAddress from;
+  private final static Logger LOGGER = LoggerFactory.getLogger(MailFilterImpl.class);
+  private final Set<String> filters;
+  private final InternetAddress from;
 
-    public MailFilterImpl(Set<String> filters, InternetAddress from) {
-        Preconditions.checkNotNull(from);
-        this.filters = filters;
-        this.from = from;
+  public MailFilterImpl(Set<String> filters, InternetAddress from) {
+    Preconditions.checkNotNull(from);
+    this.filters = filters;
+    this.from = from;
+  }
+
+  @Override
+  public MimeMessage filter(MimeMessageHelper mimeMessageHelper) throws MessagingException {
+    Map<Message.RecipientType, String[]> recipientsFiltered = this.getFilteredRecipients(mimeMessageHelper.getMimeMessage());
+
+    if (recipientsFiltered.get(Message.RecipientType.TO) != null && recipientsFiltered.get(Message.RecipientType.TO).length > 0 ||
+      recipientsFiltered.get(Message.RecipientType.CC) != null && recipientsFiltered.get(Message.RecipientType.CC).length > 0 ||
+      recipientsFiltered.get(Message.RecipientType.BCC) != null && recipientsFiltered.get(Message.RecipientType.BCC).length > 0
+    ) {
+      mimeMessageHelper.setFrom(from);
+
+      if (recipientsFiltered.get(Message.RecipientType.TO) != null && recipientsFiltered.get(Message.RecipientType.TO).length > 0) {
+        mimeMessageHelper.setTo(recipientsFiltered.get(Message.RecipientType.TO));
+      } else {
+        mimeMessageHelper.setTo(new String[0]);
+      }
+
+      if (recipientsFiltered.get(Message.RecipientType.CC) != null && recipientsFiltered.get(Message.RecipientType.CC).length > 0) {
+        mimeMessageHelper.setCc(recipientsFiltered.get(Message.RecipientType.CC));
+      } else {
+        mimeMessageHelper.setCc(new String[0]);
+      }
+
+      if (recipientsFiltered.get(Message.RecipientType.BCC) != null && recipientsFiltered.get(Message.RecipientType.BCC).length > 0) {
+        mimeMessageHelper.setBcc(recipientsFiltered.get(Message.RecipientType.BCC));
+      } else {
+        mimeMessageHelper.setBcc(new String[0]);
+      }
+
+      return mimeMessageHelper.getMimeMessage();
+    } else {
+      LOGGER.info(
+        "A mail with recipient(s) '{}' and subject '{}' was not sent because the recipient adresses were filtered by mailfilters {}",
+        Arrays.toString(mimeMessageHelper.getMimeMessage().getRecipients(Message.RecipientType.TO)), mimeMessageHelper.getMimeMessage().getSubject(), this.filters);
+      throw new MessagingException("Trying to send a mail without recipient!");
     }
+  }
 
-    @Override
-    public MimeMessage filter(MimeMessageHelper mimeMessageHelper) throws MessagingException {
-        Map<Message.RecipientType, String[]> recipientsFiltered = this.getFilteredRecipients(mimeMessageHelper.getMimeMessage());
 
-        if (recipientsFiltered.get(Message.RecipientType.TO) != null && recipientsFiltered.get(Message.RecipientType.TO).length > 0) {
-            mimeMessageHelper.setTo(recipientsFiltered.get(Message.RecipientType.TO));
-            mimeMessageHelper.setFrom(from);
-
-            if (recipientsFiltered.get(Message.RecipientType.BCC) != null && recipientsFiltered.get(Message.RecipientType.BCC).length > 0) {
-                mimeMessageHelper.setBcc(recipientsFiltered.get(Message.RecipientType.BCC));
-            }else{
-                mimeMessageHelper.setBcc(new String[0]);
-            }
-            if (recipientsFiltered.get(Message.RecipientType.CC) != null && recipientsFiltered.get(Message.RecipientType.CC).length > 0) {
-                mimeMessageHelper.setCc(recipientsFiltered.get(Message.RecipientType.CC));
-            }else{
-                mimeMessageHelper.setCc(new String[0]);
-            }
-
-            return mimeMessageHelper.getMimeMessage();
-        } else {
-            LOGGER.info(
-                    "A mail with recipient(s) '{}' and subject '{}' was not sent because the recipient adresses were filtered by mailfilters {}",
-                    Arrays.toString(mimeMessageHelper.getMimeMessage().getRecipients(Message.RecipientType.TO)), mimeMessageHelper.getMimeMessage().getSubject(), this.filters);
-            throw new MessagingException("Trying to send a mail without recipient!");
-        }
+  private String[] filterMails(Address[] recipients) {
+    if (recipients != null) {
+      if (this.filters != null && !this.filters.isEmpty()) {
+        return Stream.of(recipients).map(this::getEmailAdress).filter(s -> this.filters.stream().anyMatch(s::matches)).toArray(String[]::new);
+      } else {
+        return Stream.of(recipients).map(this::getEmailAdress).toArray(String[]::new);
+      }
+    } else {
+      return null;
     }
+  }
 
-
-    private String[] filterMails(Address[] recipients) {
-        if (recipients != null) {
-            if (this.filters != null && !this.filters.isEmpty()) {
-                return Stream.of(recipients).map(this::getEmailAdress).filter(s -> this.filters.stream().anyMatch(s::matches)).toArray(String[]::new);
-            } else {
-                return Stream.of(recipients).map(this::getEmailAdress).toArray(String[]::new);
-            }
-        } else {
-            return null;
-        }
+  private String getEmailAdress(Address recipient) {
+    if (!(recipient instanceof InternetAddress)) {
+      return recipient.toString();
+    } else {
+      return ((InternetAddress) recipient).getAddress();
     }
+  }
 
-    private String getEmailAdress(Address recipient) {
-        if (!(recipient instanceof InternetAddress)) {
-            return recipient.toString();
-        } else {
-            return ((InternetAddress) recipient).getAddress();
-        }
+  private Map<Message.RecipientType, String[]> getFilteredRecipients(MimeMessage mimeMessage) throws MessagingException {
+    Map<Message.RecipientType, String[]> result = new HashMap<>();
+
+    for (Message.RecipientType recipientType :
+      new Message.RecipientType[]{Message.RecipientType.BCC, Message.RecipientType.CC, Message.RecipientType.TO}
+    ) {
+      result.put(recipientType, filterMails(mimeMessage.getRecipients(recipientType)));
     }
-
-    private Map<Message.RecipientType, String[]> getFilteredRecipients(MimeMessage mimeMessage) throws MessagingException {
-        Map<Message.RecipientType, String[]> result = new HashMap<>();
-
-        for (Message.RecipientType recipientType :
-                new Message.RecipientType[]{Message.RecipientType.BCC, Message.RecipientType.CC, Message.RecipientType.TO}
-                ) {
-            result.put(recipientType, filterMails(mimeMessage.getRecipients(recipientType)));
-        }
-        return result;
-    }
+    return result;
+  }
 
 }
 

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
@@ -237,7 +237,7 @@ public class MailSenderImpl implements MailSender {
     int i=0;
     InternetAddress[] addresses = new InternetAddress[mails.length];
     for(String mail : mails){
-      addresses[i] = new InternetAddress(mail);
+      addresses[i++] = new InternetAddress(mail);
     }
 
     return addresses;

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
@@ -141,63 +141,63 @@ public class MailSenderImpl implements MailSender {
     }
 
     private void sendMail(Locale locale, Map<String, Object> ctx, InternetAddress[] mailTo, String mailSubject, String htmlTemplate, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, List<File> attachedFiles) throws Exception {
-        Preconditions.checkArgument(locale != null);
-        Preconditions.checkArgument(ctx != null);
-        Preconditions.checkArgument(mailTo != null && mailTo.length > 0);
-        Preconditions.checkArgument(mailSubject != null);
+      Preconditions.checkArgument(locale != null);
+      Preconditions.checkArgument(ctx != null);
+      Preconditions.checkArgument(mailTo != null && mailTo.length > 0 || mailBcc != null && mailBcc.length > 0);
+      Preconditions.checkArgument(mailSubject != null);
 
-        this.enrichContext(ctx, locale);
+      this.enrichContext(ctx, locale);
 
-        final Template template = this.freemarkerConfiguration
-                .getTemplate("mail/" + htmlTemplate + ".ftl");
-        final String htmlContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
-        final String subject = this.messageSource
-                .getMessage(mailSubject, new Object[]{}, mailSubject, locale);
+      final Template template = this.freemarkerConfiguration
+        .getTemplate("mail/" + htmlTemplate + ".ftl");
+      final String htmlContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
+      final String subject = this.messageSource
+        .getMessage(mailSubject, new Object[]{}, mailSubject, locale);
 
-        if (mailTo != null && mailTo.length > 0) {
-            final MimeMessage mimeMessage = this.javaMailSender.createMimeMessage();
-            final MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "UTF-8");
-            message.setSubject(subject);
-            message.setText(htmlContent, true);
-            message.setTo(mailTo);
+      final MimeMessage mimeMessage = this.javaMailSender.createMimeMessage();
+      final MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+      message.setSubject(subject);
+      message.setText(htmlContent, true);
 
-            if (mailCc != null && mailCc.length > 0) {
-                message.setCc(mailCc);
-            }
+      if (mailTo != null && mailTo.length > 0) {
+        message.setTo(mailTo);
+      }
 
-            if (mailBcc != null && mailBcc.length > 0) {
-                message.setBcc(mailBcc);
-            }
+      if (mailCc != null && mailCc.length > 0) {
+        message.setCc(mailCc);
+      }
 
-            if (highPriority) {
-                //https://www.chilkatsoft.com/p/p_471.asp
-                mimeMessage.addHeader("X-Priority", "1");
-                mimeMessage.addHeader("X-MSMail-Priority", "High");
-                mimeMessage.addHeader("Importance", "High");
-            }
+      if (mailBcc != null && mailBcc.length > 0) {
+        message.setBcc(mailBcc);
+      }
 
-            if (attachmentName != null) {
-                message.addAttachment(attachmentName, attachmentInputStreamSource, attachmentContentType);
-            }else{
-                if (attachedFiles!= null && !CollectionUtils.isEmpty(attachedFiles)) {
-                    for (File file : attachedFiles) {
-                        message.addAttachment(file.getName(), file);
-                    }
-                }
-            }
+      if (highPriority) {
+        //https://www.chilkatsoft.com/p/p_471.asp
+        mimeMessage.addHeader("X-Priority", "1");
+        mimeMessage.addHeader("X-MSMail-Priority", "High");
+        mimeMessage.addHeader("Importance", "High");
+      }
 
-            try {
-                this.javaMailSender.send(this.filter.filter(message));
-            } catch (Exception e) {
-                LOGGER.error("Error when sending", e);
-            }
-
-            LOGGER.info("Mail with recipient(s) {} sent.", Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.TO)));
-        } else {
-            LOGGER.warn(
-                    "A mail with recipient(s) '{}' and subject '{}' was not sent because no java mail sender is configured",
-                    Arrays.toString(mailTo), mailSubject);
+      if (attachmentName != null) {
+        message.addAttachment(attachmentName, attachmentInputStreamSource, attachmentContentType);
+      } else {
+        if (attachedFiles != null && !CollectionUtils.isEmpty(attachedFiles)) {
+          for (File file : attachedFiles) {
+            message.addAttachment(file.getName(), file);
+          }
         }
+      }
+
+      try {
+        this.javaMailSender.send(this.filter.filter(message));
+      } catch (Exception e) {
+        LOGGER.error("Error when sending", e);
+      }
+
+      LOGGER.info("Mail with recipient(s) {To: '{}', CC: '{}', BCC: '{}'} sent.",
+        Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.TO)),
+        Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.CC)),
+        Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.BCC)));
     }
 
     private void enrichContext(Map<String, Object> ctx, Locale locale) {

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
@@ -115,7 +115,7 @@ public class NoopMailSenderImpl implements MailSender {
     int i = 0;
     InternetAddress[] addresses = new InternetAddress[mails.length];
     for (String mail : mails) {
-      addresses[i] = new InternetAddress(mail);
+      addresses[i++] = new InternetAddress(mail);
     }
 
     return addresses;

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -15,6 +15,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.ui.freemarker.FreeMarkerConfigurationFactory;
 
+import javax.mail.Address;
 import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
@@ -23,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -45,6 +47,13 @@ public class MailSenderImplTest {
   public void setUp() throws Exception {
     this.javaMailSender = mock(JavaMailSender.class);
     when(javaMailSender.createMimeMessage()).thenReturn(new SMTPMessage((Session) null));
+    doAnswer(invocationOnMock -> {
+      MimeMessage mimeMessage = invocationOnMock.getArgument(0);
+      for (Address address: mimeMessage.getAllRecipients()) {
+        assertNotNull(address);
+      }
+      return null;
+    }).when(javaMailSender).send(any(MimeMessage.class));
 
     FreeMarkerConfigurationFactory factory = new FreeMarkerConfigurationFactory();
     factory.setTemplateLoaderPath("/templates");
@@ -317,6 +326,39 @@ public class MailSenderImplTest {
     Map<String, Object> parameters = new HashMap<>();
     String subject = "subject";
     String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, (String[])null, (String[])null, mailTo);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_mailTo() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test", "test2@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, null, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_mailCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test", "test2@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_mailBCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test", "test2@test.test"};
     this.mailSender.sendMail(htmlTemplate, parameters, subject, (String[])null, (String[])null, mailTo);
 
     verify(javaMailSender, times(1)).send(any(MimeMessage.class));

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -1,15 +1,10 @@
 package com.blossomproject.core.common.utils.mail;
 
-import static org.mockito.Mockito.mock;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.sun.mail.smtp.SMTPMessage;
 import freemarker.template.Configuration;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import javax.mail.internet.InternetAddress;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +13,18 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.MessageSource;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.ui.freemarker.FreeMarkerConfigurationFactory;
+
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MailSenderImplTest {
@@ -37,9 +44,18 @@ public class MailSenderImplTest {
   @Before
   public void setUp() throws Exception {
     this.javaMailSender = mock(JavaMailSender.class);
-    this.configuration = mock(Configuration.class);
+    when(javaMailSender.createMimeMessage()).thenReturn(new SMTPMessage((Session) null));
+
+    FreeMarkerConfigurationFactory factory = new FreeMarkerConfigurationFactory();
+    factory.setTemplateLoaderPath("/templates");
+    this.configuration = factory.createConfiguration();
+
     this.messageSource = mock(MessageSource.class);
+    when(messageSource.getMessage(any(), any(), any(), any())).thenReturn("Subject");
+
     this.mailFilter = mock(MailFilterImpl.class);
+    when(mailFilter.filter(any())).thenReturn(new SMTPMessage((Session) null));
+
     this.from = "blossom-test@test.fr";
     this.basePath = "basePath";
     this.filters = Sets.newHashSet("*@blossom-project.com");
@@ -77,7 +93,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      null,  "basePath", this.locale, this.mailFilter);
+      null, "basePath", this.locale, this.mailFilter);
   }
 
   @Test
@@ -85,7 +101,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class),  null, this.locale, this.mailFilter);
+      mock(MessageSource.class), null, this.locale, this.mailFilter);
   }
 
   @Test
@@ -93,7 +109,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class),  "basePath", null, this.mailFilter);
+      mock(MessageSource.class), "basePath", null, this.mailFilter);
   }
 
   @Test
@@ -101,7 +117,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-            mock(MessageSource.class), "basePath", this.locale,null );
+      mock(MessageSource.class), "basePath", this.locale, null);
   }
 
 
@@ -133,13 +149,12 @@ public class MailSenderImplTest {
     thrown.expect(IllegalArgumentException.class);
 
     String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters =Maps.newHashMap();
-    String subject =null ;
+    Map<String, Object> parameters = Maps.newHashMap();
+    String subject = null;
     InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
 
     this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
   }
-
 
 
   @Test
@@ -151,7 +166,7 @@ public class MailSenderImplTest {
     String subject = "subject";
     InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
 
-    this.mailSender.sendMail(htmlTemplate, parameters, subject,this.locale, Lists.newArrayList(), mailTo, null,null,true);
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, Lists.newArrayList(), mailTo, null, null, true);
   }
 
   @Test
@@ -161,7 +176,7 @@ public class MailSenderImplTest {
     Map<String, Object> parameters = null;
     String subject = "subject";
     InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-    this.mailSender.sendMail(htmlTemplate,parameters,subject,this.locale,mailTo, mailTo, mailTo);
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, mailTo, mailTo, mailTo);
   }
 
   @Test
@@ -181,9 +196,8 @@ public class MailSenderImplTest {
     Map<String, Object> parameters = null;
     String subject = "subject";
     InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject,this.locale,null,null,null, mailTo, mailTo, null,true);
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, null, null, null, mailTo, mailTo, null, true);
   }
-
 
 
   @Test
@@ -214,13 +228,12 @@ public class MailSenderImplTest {
     thrown.expect(IllegalArgumentException.class);
 
     String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters =Maps.newHashMap();
-    String subject =null ;
+    Map<String, Object> parameters = Maps.newHashMap();
+    String subject = null;
     String[] mailTo = {"test@test.test"};
 
     this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
   }
-
 
 
   @Test
@@ -232,7 +245,7 @@ public class MailSenderImplTest {
     String subject = "subject";
     String[] mailTo = {"test@test.test"};
 
-    this.mailSender.sendMail(htmlTemplate, parameters, subject,this.locale, Lists.newArrayList(), mailTo, null,null,true);
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, Lists.newArrayList(), mailTo, null, null, true);
   }
 
   @Test
@@ -242,7 +255,7 @@ public class MailSenderImplTest {
     Map<String, Object> parameters = null;
     String subject = "subject";
     String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate,parameters,subject,this.locale,mailTo, mailTo, mailTo);
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, mailTo, mailTo, mailTo);
   }
 
   @Test
@@ -262,6 +275,50 @@ public class MailSenderImplTest {
     Map<String, Object> parameters = null;
     String subject = "subject";
     String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject,this.locale,null,null,null, mailTo, mailTo, null,true);
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, null, null, null, mailTo, mailTo, null, true);
+  }
+
+  @Test
+  public void should_send_mail_with_mailTo() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, null, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_mailCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_mailBCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, mailTo);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_only_mailBCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, (String[])null, (String[])null, mailTo);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
   }
 }

--- a/blossom-core/blossom-core-common/src/test/resources/templates/mail/htmlTemplate.ftl
+++ b/blossom-core/blossom-core-common/src/test/resources/templates/mail/htmlTemplate.ftl
@@ -1,0 +1,1 @@
+Test template


### PR DESCRIPTION
A couple MailSender fixes:

- Allow sending mails with BCC-only recipients, so no one can see who received the message
- Fix methods sending to multiple recipients (of any type) using String[] instead of InternetAddress[]

Fixes #194 