### PR TITLE
Mailsender interface

### DIFF
--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
@@ -80,7 +80,8 @@ public class MailAutoConfiguration {
       Iterables.getFirst(availableLocales, Locale.ENGLISH),
       mailFilter,
       asyncMailSender,
-      new InternetAddress(properties.getFrom(), properties.getFromName())
+      new InternetAddress(properties.getFrom(), properties.getFromName()),
+      properties.getFilters()
     );
   }
 

--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/MailAutoConfiguration.java
@@ -2,9 +2,6 @@ package com.blossomproject.autoconfigure.core;
 
 import com.blossomproject.core.common.utils.mail.*;
 import com.google.common.collect.Iterables;
-import java.io.UnsupportedEncodingException;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -16,78 +13,93 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.mail.javamail.JavaMailSender;
 
+import javax.mail.internet.InternetAddress;
+import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
 @Configuration
-@ConditionalOnMissingBean(MailSender.class)
 @AutoConfigureAfter(MailSenderAutoConfiguration.class)
 public class MailAutoConfiguration {
 
-    @Configuration
-    @ConfigurationProperties("blossom.mail")
-    @PropertySource({"classpath:/mailsender.properties"})
-    public static class MailsenderProperties {
-        private String url;
-        private String from;
-        private String fromName;
-        private final Set<String> filters = new HashSet<>();
+  @Configuration
+  @ConfigurationProperties("blossom.mail")
+  @PropertySource({"classpath:/mailsender.properties"})
+  public static class MailsenderProperties {
+    private String url;
+    private String from;
+    private String fromName;
+    private final Set<String> filters = new HashSet<>();
 
-        public String getUrl() {
-            return url;
-        }
-
-        public void setUrl(String url) {
-            this.url = url;
-        }
-
-        public String getFrom() {
-            return from;
-        }
-
-        public void setFrom(String from) {
-            this.from = from;
-        }
-
-        public String getFromName() {
-          return fromName;
-        }
-
-        public void setFromName(String fromName) {
-          this.fromName = fromName;
-        }
-
-        public Set<String> getFilters() {
-            return filters;
-        }
+    public String getUrl() {
+      return url;
     }
 
-    @Bean
-    @ConditionalOnBean(JavaMailSender.class)
-    @ConditionalOnMissingBean(MailSender.class)
-    public MailSender blossomMailSender(JavaMailSender javaMailSender,
-                                        MessageSource messageSource,
-                                        freemarker.template.Configuration configuration,
-                                        Set<Locale> availableLocales,
-                                        MailsenderProperties properties, MailFilter mailFilter) {
-        return new MailSenderImpl(javaMailSender,
-                configuration,
-                messageSource,
-                properties.getUrl(),
-                Iterables.getFirst(availableLocales, Locale.ENGLISH), mailFilter);
+    public void setUrl(String url) {
+      this.url = url;
     }
 
-    @Bean
-    @ConditionalOnMissingBean(MailFilter.class)
-    public MailFilter blossomDefaultMailFilter(MailsenderProperties properties) throws AddressException, UnsupportedEncodingException {
-        return new MailFilterImpl(properties.getFilters(), new InternetAddress(properties.getFrom(), properties.getFromName()));
+    public String getFrom() {
+      return from;
     }
 
-    @Bean
-    @ConditionalOnMissingBean(JavaMailSender.class)
-    public MailSender blossomNoopMailSender() {
-        return new NoopMailSenderImpl();
+    public void setFrom(String from) {
+      this.from = from;
     }
+
+    public String getFromName() {
+      return fromName;
+    }
+
+    public void setFromName(String fromName) {
+      this.fromName = fromName;
+    }
+
+    public Set<String> getFilters() {
+      return filters;
+    }
+  }
+
+  @Bean
+  @ConditionalOnBean(JavaMailSender.class)
+  @ConditionalOnMissingBean(MailSender.class)
+  public MailSender blossomMailSender(JavaMailSender javaMailSender,
+                                      MessageSource messageSource,
+                                      freemarker.template.Configuration configuration,
+                                      Set<Locale> availableLocales,
+                                      MailsenderProperties properties, MailFilter mailFilter,
+                                      AsyncMailSender asyncMailSender)
+    throws UnsupportedEncodingException {
+
+    return new MailSenderImpl(
+      javaMailSender,
+      configuration,
+      messageSource,
+      properties.getUrl(),
+      Iterables.getFirst(availableLocales, Locale.ENGLISH),
+      mailFilter,
+      asyncMailSender,
+      new InternetAddress(properties.getFrom(), properties.getFromName())
+    );
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(MailFilter.class)
+  public MailFilter blossomDefaultMailFilter(MailsenderProperties properties) {
+    return new MailFilterImpl(properties.getFilters());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean({JavaMailSender.class, MailSender.class})
+  public MailSender blossomNoopMailSender() {
+    return new NoopMailSenderImpl();
+  }
+
+  @Bean("BlossomAsyncMailSender")
+  @ConditionalOnMissingBean(AsyncMailSender.class)
+  public AsyncMailSender blossomAsyncMailSender() {
+    return new AsyncMailSenderImpl();
+  }
 
 }

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/AsyncMailSender.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/AsyncMailSender.java
@@ -1,0 +1,11 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.util.concurrent.ListenableFuture;
+
+public interface AsyncMailSender {
+
+  @Async
+  ListenableFuture<BlossomMail> asyncSend(BlossomMail mail);
+
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/AsyncMailSender.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/AsyncMailSender.java
@@ -3,6 +3,13 @@ package com.blossomproject.core.common.utils.mail;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.util.concurrent.ListenableFuture;
 
+/**
+ * Enable sending a BlossomMail asynchronously for a standard MailSender.
+ * This is to circumvent the limitation that AOP cannot be applied inside the
+ * calling service, and calling methods on BlossomMail are not Spring-managed
+ *
+ * @author rlejolivet
+ */
 public interface AsyncMailSender {
 
   @Async

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/AsyncMailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/AsyncMailSenderImpl.java
@@ -1,0 +1,20 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.util.concurrent.ListenableFuture;
+
+public class AsyncMailSenderImpl implements AsyncMailSender {
+
+  @Override
+  @Async
+  public ListenableFuture<BlossomMail> asyncSend(BlossomMail mail) {
+    try {
+      mail.send();
+    } catch (Exception e) {
+      return AsyncResult.forExecutionException(e);
+    }
+    return new AsyncResult<>(mail);
+  }
+
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMail.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMail.java
@@ -2,6 +2,11 @@ package com.blossomproject.core.common.utils.mail;
 
 import org.springframework.util.concurrent.ListenableFuture;
 
+/**
+ * An email ready to be sent
+ *
+ * @author rlejolivet
+ */
 public interface BlossomMail {
 
   /**
@@ -11,6 +16,8 @@ public interface BlossomMail {
 
   /**
    * Send the email asynchronously, using an AsyncMailSender
+   *
+   * @return
    */
   ListenableFuture<BlossomMail> asyncSend();
 

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMail.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMail.java
@@ -1,0 +1,17 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.util.concurrent.ListenableFuture;
+
+public interface BlossomMail {
+
+  /**
+   * Send the email as is, synchronously.
+   */
+  void send() throws Exception;
+
+  /**
+   * Send the email asynchronously, using an AsyncMailSender
+   */
+  ListenableFuture<BlossomMail> asyncSend();
+
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailAttachment.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailAttachment.java
@@ -4,6 +4,12 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 
 import javax.mail.MessagingException;
 
+/**
+ * An attachment before being added to a sent mail.
+ * @see MimeMessageHelper#addAttachment
+ *
+ * @author rlejolivet
+ */
 public interface BlossomMailAttachment {
   void appendTo(MimeMessageHelper mimeMessageHelper) throws MessagingException;
 }

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailAttachment.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailAttachment.java
@@ -1,0 +1,9 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+
+public interface BlossomMailAttachment {
+  void appendTo(MimeMessageHelper mimeMessageHelper) throws MessagingException;
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailBuilder.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailBuilder.java
@@ -10,6 +10,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+/**
+ * Email builder with Blossom functionalities: freemarker templating, filters
+ * Note: Default implementation is not thread-safe.
+ *
+ * @author rlejolivet
+ */
 public interface BlossomMailBuilder {
 
   /**

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailBuilder.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailBuilder.java
@@ -1,0 +1,243 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.core.io.InputStreamSource;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public interface BlossomMailBuilder {
+
+  /**
+   * Add text body as a freemarker template
+   *
+   * @param textTemplate Name of a freemarker template relative to classpath:/templates/mail
+   */
+  BlossomMailBuilder textTemplate(String textTemplate);
+
+  /**
+   * Add text body as is
+   *
+   * @param textBody Content of the text body
+   */
+  BlossomMailBuilder textBody(String textBody);
+
+  /**
+   * Add text body as a freemarker template
+   *
+   * @param htmlTemplate Name of a freemarker template relative to classpath:/templates/mail
+   */
+  BlossomMailBuilder htmlTemplate(String htmlTemplate);
+
+  /**
+   * Add HTML body as is
+   *
+   * @param htmlBody Content of the HTML body
+   */
+  BlossomMailBuilder htmlBody(String htmlBody);
+
+  /**
+   * Set mail's subject
+   *
+   * @param mailSubject Mail subject
+   */
+  BlossomMailBuilder mailSubject(String mailSubject);
+
+  /**
+   * Add key/value pair to the Freemarker context for body rendering
+   *
+   * @param key   Key in the freemarker template
+   * @param value Value to render in the template
+   */
+  BlossomMailBuilder addContext(String key, Object value);
+
+  /**
+   * Add a map of key/value pairs to the Freemarker context for body rendering
+   *
+   * @param context Context to get key/value pairs from
+   */
+  BlossomMailBuilder addContext(Map<String, Object> context);
+
+  /**
+   * Set the locale for freemarker templates traductions
+   *
+   * @param locale Locale to use in templates
+   */
+  BlossomMailBuilder locale(Locale locale);
+
+  /**
+   * Set the email as high priority
+   *
+   * @param highPriority true for high priority
+   */
+  BlossomMailBuilder highPriority(Boolean highPriority);
+
+  /**
+   * Set mail from
+   *
+   * @param from Address to send mail as
+   */
+  BlossomMailBuilder from(InternetAddress from);
+
+  /**
+   * Set mail from
+   *
+   * @param address Address to send mail as
+   * @throws AddressException if the parse failed
+   */
+  BlossomMailBuilder from(String address) throws AddressException;
+
+  /**
+   * Set mail from
+   *
+   * @param address Address to send mail as
+   * @param name    Name to send mail as
+   * @throws UnsupportedEncodingException if the personal name can't be encoded in the default charset
+   */
+  BlossomMailBuilder from(String address, String name) throws UnsupportedEncodingException;
+
+  /**
+   * Set mail reply to
+   *
+   * @param replyTo Address to reply to
+   */
+  BlossomMailBuilder replyTo(InternetAddress replyTo);
+
+  /**
+   * Set mail reply to
+   *
+   * @param address Address to reply to
+   * @throws AddressException if the parse failed
+   */
+  BlossomMailBuilder replyTo(String address) throws AddressException;
+
+  /**
+   * Set mail reply to
+   *
+   * @param address Address to reply to
+   * @param name    Name to send reply to
+   * @throws UnsupportedEncodingException if the personal name can't be encoded in the default charset
+   */
+  BlossomMailBuilder replyTo(String address, String name) throws UnsupportedEncodingException;
+
+  /**
+   * Add attachment as file
+   *
+   * @param file File to add as attachment
+   */
+  BlossomMailBuilder addAttachment(File file);
+
+  /**
+   * Add attachment as Spring's InputStreamSource
+   *
+   * @param filename          Filename to use for the attachment
+   * @param inputStreamSource InputStreamSource for the attachment content
+   * @param contentType       Attachment content type
+   */
+  BlossomMailBuilder addAttachment(String filename, InputStreamSource inputStreamSource, String contentType);
+
+  /**
+   * Add attachment as Blossom's BlossomMailAttachment
+   *
+   * @param attachment Attachment to add
+   */
+  BlossomMailBuilder addAttachment(BlossomMailAttachment attachment);
+
+  /**
+   * Add regex filter for the mail's recipients
+   * Recipients's email addresses that do not match at least one filter will not receive the email
+   *
+   * @param filter Filter regex
+   */
+  BlossomMailBuilder addFilter(String filter);
+
+  /**
+   * Add regex filter for the mail's recipients
+   * Recipients's email addresses that do not match at least one filter will not receive the email
+   *
+   * @param regex Filter regex
+   */
+  BlossomMailBuilder addFilter(Pattern regex);
+
+  /**
+   * Add mail TO recipient
+   *
+   * @param address TO recipient address
+   */
+  BlossomMailBuilder addTo(InternetAddress address);
+
+  /**
+   * Add mail TO recipient
+   *
+   * @param address TO recipient address
+   * @throws AddressException if the parse failed
+   */
+  BlossomMailBuilder addTo(String address) throws AddressException;
+
+  /**
+   * Add mail TO recipient
+   *
+   * @param address TO recipient address
+   * @param name    TO recipient name
+   * @throws UnsupportedEncodingException if the personal name can't be encoded in the default charset
+   */
+  BlossomMailBuilder addTo(String address, String name) throws UnsupportedEncodingException;
+
+  /**
+   * Add mail CC recipient
+   *
+   * @param address CC recipient address
+   */
+  BlossomMailBuilder addCc(InternetAddress address);
+
+  /**
+   * Add mail CC recipient
+   *
+   * @param address CC recipient address
+   * @throws AddressException if the parse failed
+   */
+  BlossomMailBuilder addCc(String address) throws AddressException;
+
+  /**
+   * Add mail CC recipient
+   *
+   * @param address CC recipient address
+   * @param name    CC recipient name
+   * @throws UnsupportedEncodingException if the personal name can't be encoded in the default charset
+   */
+  BlossomMailBuilder addCc(String address, String name) throws UnsupportedEncodingException;
+
+  /**
+   * Add mail BCC recipient
+   *
+   * @param address BCC recipient address
+   */
+  BlossomMailBuilder addBcc(InternetAddress address);
+
+  /**
+   * Add mail BCC recipient
+   *
+   * @param address BCC recipient address
+   * @throws AddressException if the parse failed
+   */
+  BlossomMailBuilder addBcc(String address) throws AddressException;
+
+  /**
+   * Add mail BCC recipient
+   *
+   * @param address BCC recipient address
+   * @param name    CC recipient name
+   * @throws UnsupportedEncodingException if the personal name can't be encoded in the default charset
+   */
+  BlossomMailBuilder addBcc(String address, String name) throws UnsupportedEncodingException;
+
+  /**
+   * Build BlossomMail from this builder
+   */
+  BlossomMail build();
+
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailBuilderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailBuilderImpl.java
@@ -1,0 +1,223 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.core.io.InputStreamSource;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public abstract class BlossomMailBuilderImpl implements BlossomMailBuilder {
+
+  protected String textTemplate;
+  protected String textBody;
+  protected String htmlTemplate;
+  protected String htmlBody;
+  protected String mailSubject;
+  protected Locale locale = Locale.getDefault();
+  protected InternetAddress from;
+  protected InternetAddress replyTo;
+  protected Boolean highPriority = false;
+
+  protected Map<String, Object> ctx = new HashMap<>();
+  protected List<BlossomMailAttachment> attachments = new ArrayList<>();
+  protected Set<Pattern> filters = new HashSet<>();
+
+  protected Set<InternetAddress> to = new HashSet<>();
+  protected Set<InternetAddress> cc = new HashSet<>();
+  protected Set<InternetAddress> bcc = new HashSet<>();
+
+  /*
+   * Utils methods
+   */
+
+  protected Set<InternetAddress> filter(Set<InternetAddress> recipients) {
+    if (filters.isEmpty() || recipients == null) {
+      return recipients;
+    }
+    return recipients.stream()
+      .filter(address -> filters.stream().anyMatch(pattern -> pattern.matcher(address.getAddress()).find()))
+      .collect(Collectors.toSet());
+  }
+
+  /*
+   * Builder interface
+   */
+
+  @Override
+  public BlossomMailBuilder textTemplate(String textTemplate) {
+    this.textTemplate = textTemplate;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder textBody(String textBody) {
+    this.textBody = textBody;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder htmlTemplate(String htmlTemplate) {
+    this.htmlTemplate = htmlTemplate;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder htmlBody(String htmlBody) {
+    this.htmlBody = htmlBody;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder mailSubject(String mailSubject) {
+    this.mailSubject = mailSubject;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addContext(String key, Object value) {
+    this.ctx.put(key, value);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addContext(Map<String, Object> context) {
+    this.ctx.putAll(context);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder locale(Locale locale) {
+    this.locale = locale;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder highPriority(Boolean highPriority) {
+    this.highPriority = highPriority;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder from(InternetAddress from) {
+    this.from = from;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder from(String address) throws AddressException {
+    this.from = new InternetAddress(address);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder from(String address, String name) throws UnsupportedEncodingException {
+    this.from = new InternetAddress(address, name);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder replyTo(InternetAddress replyTo) {
+    this.replyTo = replyTo;
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder replyTo(String address) throws AddressException {
+    this.replyTo = new InternetAddress(address);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder replyTo(String address, String name) throws UnsupportedEncodingException {
+    this.replyTo = new InternetAddress(address, name);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addAttachment(File file) {
+    this.attachments.add(new FileMailAttachment(file));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addAttachment(String filename, InputStreamSource inputStreamSource, String contentType) {
+    this.attachments.add(new InputStreamMailAttachment(filename, inputStreamSource, contentType));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addAttachment(BlossomMailAttachment attachment) {
+    this.attachments.add(attachment);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addFilter(String filter) {
+    this.filters.add(Pattern.compile(filter));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addFilter(Pattern regex) {
+    this.filters.add(regex);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addTo(InternetAddress address) {
+    this.to.add(address);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addTo(String address) throws AddressException {
+    this.to.add(new InternetAddress(address));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addTo(String address, String name) throws UnsupportedEncodingException {
+    this.to.add(new InternetAddress(address, name));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addCc(InternetAddress address) {
+    this.cc.add(address);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addCc(String address) throws AddressException {
+    this.cc.add(new InternetAddress(address));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addCc(String address, String name) throws UnsupportedEncodingException {
+    this.cc.add(new InternetAddress(address, name));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addBcc(InternetAddress address) {
+    this.bcc.add(address);
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addBcc(String address) throws AddressException {
+    this.bcc.add(new InternetAddress(address));
+    return this;
+  }
+
+  @Override
+  public BlossomMailBuilder addBcc(String address, String name) throws UnsupportedEncodingException {
+    this.bcc.add(new InternetAddress(address, name));
+    return this;
+  }
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/BlossomMailImpl.java
@@ -1,0 +1,114 @@
+package com.blossomproject.core.common.utils.mail;
+
+import javax.mail.internet.InternetAddress;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public abstract class BlossomMailImpl implements BlossomMail {
+
+  private final String textTemplate;
+  private final String textBody;
+  private final String htmlTemplate;
+  private final String htmlBody;
+  private final String mailSubject;
+  private final Locale locale;
+  private final InternetAddress from;
+  private final InternetAddress replyTo;
+  private final Boolean highPriority;
+
+  private final Map<String, Object> ctx;
+  private final List<BlossomMailAttachment> attachments;
+
+  private final Set<InternetAddress> to;
+  private final Set<InternetAddress> cc;
+  private final Set<InternetAddress> bcc;
+
+  protected BlossomMailImpl(String textTemplate,
+                            String textBody,
+                            String htmlTemplate,
+                            String htmlBody,
+                            String mailSubject,
+                            Locale locale,
+                            InternetAddress from,
+                            InternetAddress replyTo,
+                            Boolean highPriority,
+                            Map<String, Object> ctx,
+                            List<BlossomMailAttachment> attachments,
+                            Set<InternetAddress> to,
+                            Set<InternetAddress> cc,
+                            Set<InternetAddress> bcc) {
+    this.textTemplate = textTemplate;
+    this.textBody = textBody;
+    this.htmlTemplate = htmlTemplate;
+    this.htmlBody = htmlBody;
+    this.mailSubject = mailSubject;
+    this.locale = locale;
+    this.from = from;
+    this.replyTo = replyTo;
+    this.highPriority = highPriority;
+    this.ctx = ctx;
+    this.attachments = attachments;
+    this.to = to;
+    this.cc = cc;
+    this.bcc = bcc;
+  }
+
+  public String getTextTemplate() {
+    return textTemplate;
+  }
+
+  public String getTextBody() {
+    return textBody;
+  }
+
+  public String getHtmlTemplate() {
+    return htmlTemplate;
+  }
+
+  public String getHtmlBody() {
+    return htmlBody;
+  }
+
+  public String getMailSubject() {
+    return mailSubject;
+  }
+
+  public Locale getLocale() {
+    return locale;
+  }
+
+  public InternetAddress getFrom() {
+    return from;
+  }
+
+  public InternetAddress getReplyTo() {
+    return replyTo;
+  }
+
+  public Boolean getHighPriority() {
+    return highPriority;
+  }
+
+  public Map<String, Object> getCtx() {
+    return ctx;
+  }
+
+  public List<BlossomMailAttachment> getAttachments() {
+    return attachments;
+  }
+
+  public Set<InternetAddress> getTo() {
+    return to;
+  }
+
+  public Set<InternetAddress> getCc() {
+    return cc;
+  }
+
+  public Set<InternetAddress> getBcc() {
+    return bcc;
+  }
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSender.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSender.java
@@ -1,0 +1,76 @@
+package com.blossomproject.core.common.utils.mail;
+
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.mail.internet.InternetAddress;
+import org.springframework.core.io.InputStreamSource;
+
+/**
+ * Created by Maël Gargadennnec on 04/05/2017.
+ */
+@Deprecated
+public interface DeprecatedMailSender {
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String... mailTo) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String... mailTo)
+    throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
+    List<File> attachedFiles, String... mailTo) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String[] mailTo,  String[] mailCc, String[] mailBcc)
+    throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
+    List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception;
+
+  @Deprecated
+  void sendMail (String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
+    List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource,
+    String attachmentContentType, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority ) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress... mailTo) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress... mailTo)
+    throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
+    List<File> attachedFiles, InternetAddress... mailTo) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress[] mailTo,  InternetAddress[] mailCc, InternetAddress[] mailBcc)
+    throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
+    List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception;
+
+  @Deprecated
+  void sendMail (String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
+    List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception;
+
+  @Deprecated
+  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource,
+    String attachmentContentType, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority ) throws Exception;
+
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImpl.java
@@ -10,33 +10,35 @@ import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 
 /**
  * Created by Maël Gargadennnec on 04/05/2017.
  */
-@Async
 public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
 
   protected abstract BlossomMailBuilder builder();
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String... mailTo) throws Exception {
     BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
     recipients(builder, mailTo).build().send();
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String... mailTo) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String... mailTo) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, null, null);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
     BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
@@ -44,16 +46,19 @@ public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
     recipients(builder, mailCc, mailBcc).build().send();
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo, mailCc, mailBcc);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, mailCc, mailBcc, false);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
     BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
@@ -65,6 +70,7 @@ public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
       .build().send();
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
     BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
@@ -76,6 +82,7 @@ public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
       .build().send();
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress... mailTo)
     throws Exception {
@@ -83,16 +90,19 @@ public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
     recipients(builder, mailTo).build().send();
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress... mailTo) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress... mailTo) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, null, null);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
     BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
@@ -100,16 +110,19 @@ public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
     recipients(builder, mailCc, mailBcc).build().send();
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo, mailCc, mailBcc);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
     this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, mailCc, mailBcc, false);
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
     BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
@@ -121,6 +134,7 @@ public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
       .build().send();
   }
 
+  @Async
   @Override
   public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
     BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImpl.java
@@ -1,0 +1,202 @@
+package com.blossomproject.core.common.utils.mail;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.springframework.core.io.InputStreamSource;
+import org.springframework.scheduling.annotation.Async;
+
+import javax.mail.internet.InternetAddress;
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+
+/**
+ * Created by Maël Gargadennnec on 04/05/2017.
+ */
+@Async
+public abstract class DeprecatedMailSenderImpl implements DeprecatedMailSender {
+
+  protected abstract BlossomMailBuilder builder();
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String... mailTo) throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    recipients(builder, mailTo).build().send();
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String... mailTo) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String... mailTo) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, null, null);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    builder = recipients(builder, mailTo);
+    recipients(builder, mailCc, mailBcc).build().send();
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo, mailCc, mailBcc);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, mailCc, mailBcc, false);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    builder = recipients(builder, mailTo);
+    builder = recipients(builder, mailCc, mailBcc);
+    attachments(builder, attachedFiles)
+      .locale(locale)
+      .highPriority(highPriority)
+      .build().send();
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    builder = recipients(builder, mailTo);
+    builder = recipients(builder, mailCc, mailBcc);
+    attachments(builder, attachmentName, attachmentInputStreamSource, attachmentContentType)
+      .locale(locale)
+      .highPriority(highPriority)
+      .build().send();
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress... mailTo)
+    throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    recipients(builder, mailTo).build().send();
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress... mailTo) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress... mailTo) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, null, null);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    builder = recipients(builder, mailTo);
+    recipients(builder, mailCc, mailBcc).build().send();
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo, mailCc, mailBcc);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
+    this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, mailCc, mailBcc, false);
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    builder = recipients(builder, mailTo);
+    builder = recipients(builder, mailCc, mailBcc);
+    attachments(builder, attachedFiles)
+      .locale(locale)
+      .highPriority(highPriority)
+      .build().send();
+  }
+
+  @Override
+  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
+    BlossomMailBuilder builder = defaultArgs(htmlTemplate, ctx, mailSubject);
+    builder = recipients(builder, mailTo);
+    builder = recipients(builder, mailCc, mailBcc);
+    attachments(builder, attachmentName, attachmentInputStreamSource, attachmentContentType)
+      .locale(locale)
+      .highPriority(highPriority)
+      .build().send();
+  }
+
+  private BlossomMailBuilder defaultArgs(String htmlTemplate, Map<String, Object> ctx, String mailSubject) {
+    Preconditions.checkArgument(ctx != null);
+    return builder()
+      .htmlTemplate(htmlTemplate)
+      .addContext(ctx)
+      .mailSubject(mailSubject);
+  }
+
+  private BlossomMailBuilder recipients(BlossomMailBuilder builder, String[] mailTo) throws Exception {
+    if (mailTo != null) {
+      for (String to : mailTo) {
+        builder = builder.addTo(to);
+      }
+    }
+    return builder;
+  }
+
+  private BlossomMailBuilder recipients(BlossomMailBuilder builder, String[] mailCc, String[] mailBcc) throws Exception {
+    if (mailCc != null) {
+      for (String cc : mailCc) {
+        builder = builder.addCc(cc);
+      }
+    }
+    if (mailBcc != null) {
+      for (String bcc : mailBcc) {
+        builder = builder.addBcc(bcc);
+      }
+    }
+    return builder;
+  }
+
+  private BlossomMailBuilder recipients(BlossomMailBuilder builder, InternetAddress[] mailTo) {
+    if (mailTo != null) {
+      for (InternetAddress to : mailTo) {
+        builder = builder.addTo(to);
+      }
+    }
+    return builder;
+  }
+
+  private BlossomMailBuilder recipients(BlossomMailBuilder builder, InternetAddress[] mailCc, InternetAddress[] mailBcc) {
+    if (mailCc != null) {
+      for (InternetAddress cc : mailCc) {
+        builder = builder.addCc(cc);
+      }
+    }
+    if (mailBcc != null) {
+      for (InternetAddress bcc : mailBcc) {
+        builder = builder.addBcc(bcc);
+      }
+    }
+    return builder;
+  }
+
+  private BlossomMailBuilder attachments(BlossomMailBuilder builder, List<File> attachedFiles) {
+    if (attachedFiles != null) {
+      for (File file : attachedFiles) {
+        builder = builder.addAttachment(file);
+      }
+    }
+    return builder;
+  }
+
+  private BlossomMailBuilder attachments(BlossomMailBuilder builder, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType) {
+    return builder.addAttachment(attachmentName, attachmentInputStreamSource, attachmentContentType);
+  }
+
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/FileMailAttachment.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/FileMailAttachment.java
@@ -1,0 +1,20 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+import java.io.File;
+
+public class FileMailAttachment implements BlossomMailAttachment {
+
+  private final File file;
+
+  public FileMailAttachment(File file) {
+    this.file = file;
+  }
+
+  @Override
+  public void appendTo(MimeMessageHelper mimeMessageHelper) throws MessagingException {
+    mimeMessageHelper.addAttachment(file.getName(), file);
+  }
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/InputStreamMailAttachment.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/InputStreamMailAttachment.java
@@ -1,0 +1,24 @@
+package com.blossomproject.core.common.utils.mail;
+
+import org.springframework.core.io.InputStreamSource;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+
+public class InputStreamMailAttachment implements BlossomMailAttachment {
+
+  private final String filename;
+  private final InputStreamSource source;
+  private final String contentType;
+
+  public InputStreamMailAttachment(String filename, InputStreamSource source, String contentType) {
+    this.filename = filename;
+    this.source = source;
+    this.contentType = contentType;
+  }
+
+  @Override
+  public void appendTo(MimeMessageHelper mimeMessageHelper) throws MessagingException {
+    mimeMessageHelper.addAttachment(filename, source, contentType);
+  }
+}

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilter.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilter.java
@@ -5,6 +5,15 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+/**
+ * Deprecated filter applied to a MimeMessageHelper just before sending it in
+ * MailSender.
+ * <p>
+ * For current recipient filtering functionality, use the BlossomMailBuilder methods
+ *
+ * @see BlossomMailBuilder#addFilter
+ */
+@Deprecated
 public interface MailFilter {
-    MimeMessage filter(MimeMessageHelper mimeMessageHelper) throws MessagingException;
+  MimeMessage filter(MimeMessageHelper mimeMessageHelper) throws MessagingException;
 }

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
@@ -1,6 +1,5 @@
 package com.blossomproject.core.common.utils.mail;
 
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.mail.javamail.MimeMessageHelper;

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailFilterImpl.java
@@ -19,12 +19,9 @@ import java.util.stream.Stream;
 public class MailFilterImpl implements MailFilter {
   private final static Logger LOGGER = LoggerFactory.getLogger(MailFilterImpl.class);
   private final Set<String> filters;
-  private final InternetAddress from;
 
-  public MailFilterImpl(Set<String> filters, InternetAddress from) {
-    Preconditions.checkNotNull(from);
+  public MailFilterImpl(Set<String> filters) {
     this.filters = filters;
-    this.from = from;
   }
 
   @Override
@@ -39,8 +36,6 @@ public class MailFilterImpl implements MailFilter {
       isRecipientsArrayNotEmpty(recipientsCc) ||
       isRecipientsArrayNotEmpty(recipientsBcc)
     ) {
-      mimeMessageHelper.setFrom(from);
-
       mimeMessageHelper.setTo(isRecipientsArrayNotEmpty(recipientsTo) ? recipientsTo : new String[0]);
       mimeMessageHelper.setCc(isRecipientsArrayNotEmpty(recipientsCc) ? recipientsCc : new String[0]);
       mimeMessageHelper.setBcc(isRecipientsArrayNotEmpty(recipientsBcc) ? recipientsBcc : new String[0]);

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSender.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSender.java
@@ -1,68 +1,7 @@
 package com.blossomproject.core.common.utils.mail;
 
-import java.io.File;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import javax.mail.internet.InternetAddress;
-import org.springframework.core.io.InputStreamSource;
+public interface MailSender extends DeprecatedMailSender {
 
-/**
- * Created by Maël Gargadennnec on 04/05/2017.
- */
-public interface MailSender {
-
-  @Deprecated
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String... mailTo) throws Exception;
-
-  @Deprecated
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String... mailTo)
-    throws Exception;
-
-  @Deprecated
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    List<File> attachedFiles, String... mailTo) throws Exception;
-
-  @Deprecated
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception;
-
-  @Deprecated
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String[] mailTo,  String[] mailCc, String[] mailBcc)
-    throws Exception;
-
-  @Deprecated
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception;
-
-  @Deprecated
-  void sendMail (String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception;
-
-  @Deprecated
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource,
-    String attachmentContentType, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority ) throws Exception;
-
-
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress... mailTo) throws Exception;
-
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress... mailTo)
-    throws Exception;
-
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    List<File> attachedFiles, InternetAddress... mailTo) throws Exception;
-
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception;
-
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress[] mailTo,  InternetAddress[] mailCc, InternetAddress[] mailBcc)
-    throws Exception;
-
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception;
-
-  void sendMail (String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-    List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception;
-
-  void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource,
-    String attachmentContentType, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority ) throws Exception;
+  BlossomMailBuilder builder();
 
 }

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSender.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSender.java
@@ -1,5 +1,11 @@
 package com.blossomproject.core.common.utils.mail;
 
+/**
+ * Produce builders able to send emails
+ *
+ * @author rlejolivet
+ * @see BlossomMailBuilder
+ */
 public interface MailSender extends DeprecatedMailSender {
 
   BlossomMailBuilder builder();

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
@@ -107,20 +107,28 @@ public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSend
     final MimeMessage mimeMessage = this.javaMailSender.createMimeMessage();
     final MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "UTF-8");
 
+    String htmlContent = null;
     if (mail.getHtmlTemplate() != null) {
       final Template template = this.freemarkerConfiguration.getTemplate("mail/" + mail.getHtmlTemplate() + ".ftl");
-      final String htmlContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
-      message.setText(htmlContent, true);
+      htmlContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
     } else if (mail.getHtmlBody() != null) {
-      message.setText(mail.getHtmlBody(), true);
+      htmlContent = mail.getHtmlBody();
     }
 
+    String textContent = null;
     if (mail.getTextTemplate() != null) {
       final Template template = this.freemarkerConfiguration.getTemplate("mail/" + mail.getTextTemplate() + ".ftl");
-      final String textContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
-      message.setText(textContent, false);
+      textContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
     } else if (mail.getTextBody() != null) {
-      message.setText(mail.getTextBody(), false);
+      textContent = mail.getTextBody();
+    }
+
+    if (htmlContent != null && textContent != null) {
+      message.setText(textContent, htmlContent);
+    } else if (htmlContent != null) {
+      message.setText(htmlContent, true);
+    } else if (textContent != null) {
+      message.setText(textContent, false);
     }
 
     message.setFrom(mail.getFrom());

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
@@ -1,245 +1,202 @@
 package com.blossomproject.core.common.utils.mail;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import freemarker.template.*;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
-import org.springframework.core.io.InputStreamSource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
-import org.springframework.util.CollectionUtils;
+import org.springframework.util.concurrent.ListenableFuture;
 
 import javax.mail.Message;
+import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
+public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSender {
 
-/**
- * Created by Maël Gargadennnec on 04/05/2017.
- */
-@Async
-public class MailSenderImpl implements MailSender {
+  private final static Logger LOGGER = LoggerFactory.getLogger(MailSenderImpl.class);
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(MailSenderImpl.class);
+  private final JavaMailSender javaMailSender;
+  private final Configuration freemarkerConfiguration;
+  private final MessageSource messageSource;
+  private final String basePath;
+  private final Locale defaultLocale;
+  private final MailFilter filter;
+  private final AsyncMailSender asyncMailSender;
+  private final InternetAddress from;
 
-    private final JavaMailSender javaMailSender;
-    private final Configuration freemarkerConfiguration;
-    private final MessageSource messageSource;
-    private final String basePath;
-    private final Locale defaultLocale;
-    private final MailFilter filter;
-
-    public MailSenderImpl(JavaMailSender javaMailSender, Configuration freemarkerConfiguration,
-                          MessageSource messageSource, String basePath, Locale defaultLocale,
-                          MailFilter filter) {
-        Preconditions.checkNotNull(javaMailSender);
-        Preconditions.checkNotNull(freemarkerConfiguration);
-        Preconditions.checkNotNull(messageSource);
-        Preconditions.checkNotNull(basePath);
-        Preconditions.checkNotNull(defaultLocale);
-        Preconditions.checkNotNull(filter);
-        this.javaMailSender = javaMailSender;
-        this.freemarkerConfiguration = freemarkerConfiguration;
-        this.messageSource = messageSource;
-        this.basePath = basePath;
-        this.defaultLocale = defaultLocale;
-        this.filter = filter;
-    }
-
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject,
-      String... mailTo)
-      throws Exception {
-      this.sendMail(htmlTemplate, ctx, mailSubject, this.defaultLocale, mailTo);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String... mailTo) throws Exception {
-      this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String... mailTo) throws Exception {
-      this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, null, null);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
-      this.sendMail(htmlTemplate, ctx, mailSubject, this.defaultLocale, mailTo, mailCc, mailBcc);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
-      this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo, mailCc, mailBcc);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
-      this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, mailCc, mailBcc, false);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
-      this.sendMail(locale,ctx, convertToInternetAddress(mailTo),mailSubject,htmlTemplate,convertToInternetAddress(mailCc),convertToInternetAddress(mailBcc),highPriority,null,null,null, attachedFiles);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
-      this.sendMail(locale,ctx,convertToInternetAddress(mailTo),mailSubject,htmlTemplate,convertToInternetAddress(mailCc),convertToInternetAddress(mailBcc),highPriority,attachmentName,attachmentInputStreamSource,attachmentContentType,null);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress... mailTo)
-            throws Exception {
-        this.sendMail(htmlTemplate, ctx, mailSubject, this.defaultLocale, mailTo);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,InternetAddress... mailTo) throws Exception {
-        this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress... mailTo) throws Exception {
-        this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, null, null);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
-        this.sendMail(htmlTemplate, ctx, mailSubject, this.defaultLocale, mailTo, mailCc, mailBcc);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
-        this.sendMail(htmlTemplate, ctx, mailSubject, locale, Lists.newArrayList(), mailTo, mailCc, mailBcc);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
-        this.sendMail(htmlTemplate, ctx, mailSubject, locale, attachedFiles, mailTo, mailCc, mailBcc, false);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
-        this.sendMail(locale,ctx,mailTo,mailSubject,htmlTemplate,mailCc,mailBcc,highPriority,null,null,null,attachedFiles);
-    }
-
-    @Override
-    public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
-        this.sendMail(locale,ctx,mailTo,mailSubject,htmlTemplate,mailCc,mailBcc,highPriority,attachmentName,attachmentInputStreamSource,attachmentContentType,null);
-    }
-
-    private void sendMail(Locale locale, Map<String, Object> ctx, InternetAddress[] mailTo, String mailSubject, String htmlTemplate, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, List<File> attachedFiles) throws Exception {
-      Preconditions.checkArgument(locale != null);
-      Preconditions.checkArgument(ctx != null);
-      Preconditions.checkArgument(mailTo != null && mailTo.length > 0 || mailBcc != null && mailBcc.length > 0);
-      Preconditions.checkArgument(mailSubject != null);
-
-      this.enrichContext(ctx, locale);
-
-      final Template template = this.freemarkerConfiguration
-        .getTemplate("mail/" + htmlTemplate + ".ftl");
-      final String htmlContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
-      final String subject = this.messageSource
-        .getMessage(mailSubject, new Object[]{}, mailSubject, locale);
-
-      final MimeMessage mimeMessage = this.javaMailSender.createMimeMessage();
-      final MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "UTF-8");
-      message.setSubject(subject);
-      message.setText(htmlContent, true);
-
-      if (mailTo != null && mailTo.length > 0) {
-        message.setTo(mailTo);
-      }
-
-      if (mailCc != null && mailCc.length > 0) {
-        message.setCc(mailCc);
-      }
-
-      if (mailBcc != null && mailBcc.length > 0) {
-        message.setBcc(mailBcc);
-      }
-
-      if (highPriority) {
-        //https://www.chilkatsoft.com/p/p_471.asp
-        mimeMessage.addHeader("X-Priority", "1");
-        mimeMessage.addHeader("X-MSMail-Priority", "High");
-        mimeMessage.addHeader("Importance", "High");
-      }
-
-      if (attachmentName != null) {
-        message.addAttachment(attachmentName, attachmentInputStreamSource, attachmentContentType);
-      } else {
-        if (attachedFiles != null && !CollectionUtils.isEmpty(attachedFiles)) {
-          for (File file : attachedFiles) {
-            message.addAttachment(file.getName(), file);
-          }
-        }
-      }
-
-      try {
-        this.javaMailSender.send(this.filter.filter(message));
-      } catch (Exception e) {
-        LOGGER.error("Error when sending", e);
-      }
-
-      LOGGER.info("Mail with recipient(s) {To: '{}', CC: '{}', BCC: '{}'} sent.",
-        Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.TO)),
-        Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.CC)),
-        Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.BCC)));
-    }
-
-    private void enrichContext(Map<String, Object> ctx, Locale locale) {
-        ctx.put("basePath", this.basePath);
-        ctx.put("message", new MessageResolverMethod(this.messageSource, locale));
-        ctx.put("lang", locale);
-    }
-
-    private class MessageResolverMethod implements TemplateMethodModelEx {
-
-        private MessageSource messageSource;
-        private Locale locale;
-
-        public MessageResolverMethod(MessageSource messageSource, Locale locale) {
-            this.messageSource = messageSource;
-            this.locale = locale;
-        }
-
-        @Override
-        public Object exec(List arguments) throws TemplateModelException {
-            if (arguments.size() != 1) {
-                throw new TemplateModelException("Wrong number of arguments");
-            }
-            String code = ((SimpleScalar) arguments.get(0)).getAsString();
-            if (code == null || code.isEmpty()) {
-                throw new TemplateModelException("Invalid code value '" + code + "'");
-            }
-            return messageSource.getMessage(code, null, locale);
-        }
-    }
-
-  private InternetAddress[] convertToInternetAddress(String[] mails) throws AddressException {
-    if(mails == null){
-      return null;
-    }
-
-    int i=0;
-    InternetAddress[] addresses = new InternetAddress[mails.length];
-    for(String mail : mails){
-      addresses[i++] = new InternetAddress(mail);
-    }
-
-    return addresses;
+  public MailSenderImpl(JavaMailSender javaMailSender, Configuration freemarkerConfiguration,
+                        MessageSource messageSource, String basePath, Locale defaultLocale,
+                        MailFilter filter, AsyncMailSender asyncMailSender, InternetAddress from) {
+    Preconditions.checkNotNull(javaMailSender);
+    Preconditions.checkNotNull(freemarkerConfiguration);
+    Preconditions.checkNotNull(messageSource);
+    Preconditions.checkNotNull(basePath);
+    Preconditions.checkNotNull(defaultLocale);
+    Preconditions.checkNotNull(filter);
+    this.javaMailSender = javaMailSender;
+    this.freemarkerConfiguration = freemarkerConfiguration;
+    this.messageSource = messageSource;
+    this.basePath = basePath;
+    this.defaultLocale = defaultLocale;
+    this.filter = filter;
+    this.asyncMailSender = asyncMailSender;
+    this.from = from;
   }
+
+  private class BlossomMailBuilder extends BlossomMailBuilderImpl {
+    private final MailSenderImpl mailSender;
+
+    BlossomMailBuilder(MailSenderImpl mailSender) {
+      this.mailSender = mailSender;
+    }
+
+    @Override
+    public BlossomMail build() {
+      return new BlossomMail(textTemplate, textBody, htmlTemplate, htmlBody, mailSubject, locale, from, replyTo,
+        highPriority, ctx, attachments, filter(to), filter(cc), filter(bcc), mailSender);
+    }
+  }
+
+  private class BlossomMail extends BlossomMailImpl {
+    private final MailSenderImpl mailSender;
+
+    BlossomMail(String textTemplate, String textBody, String htmlTemplate, String htmlBody, String mailSubject,
+                Locale locale, InternetAddress from, InternetAddress replyTo, Boolean highPriority,
+                Map<String, Object> ctx, List<BlossomMailAttachment> attachments,
+                Set<InternetAddress> to, Set<InternetAddress> cc, Set<InternetAddress> bcc, MailSenderImpl mailSender) {
+      super(textTemplate, textBody, htmlTemplate, htmlBody, mailSubject, locale, from, replyTo, highPriority, ctx, attachments, to, cc, bcc);
+      this.mailSender = mailSender;
+    }
+
+    @Override
+    public void send() throws Exception {
+      mailSender.send(this);
+    }
+
+    @Override
+    public ListenableFuture<com.blossomproject.core.common.utils.mail.BlossomMail> asyncSend() {
+      return mailSender.sendAsync(this);
+    }
+  }
+
+  private ListenableFuture<com.blossomproject.core.common.utils.mail.BlossomMail> sendAsync(com.blossomproject.core.common.utils.mail.BlossomMail mail) {
+    return asyncMailSender.asyncSend(mail);
+  }
+
+  @Override
+  public com.blossomproject.core.common.utils.mail.BlossomMailBuilder builder() {
+    BlossomMailBuilder ret = new BlossomMailBuilder(this);
+    ret.locale(defaultLocale);
+    ret.from(from);
+    return ret;
+  }
+
+  private void send(BlossomMailImpl mail) throws Exception {
+    Preconditions.checkArgument(mail.getLocale() != null);
+    Preconditions.checkArgument(mail.getCtx() != null);
+    Preconditions.checkArgument(mail.getTo() != null && !mail.getTo().isEmpty() || mail.getBcc() != null && !mail.getBcc().isEmpty());
+    Preconditions.checkArgument(mail.getMailSubject() != null);
+
+    final Map<String, Object> ctx = new HashMap<>(mail.getCtx());
+    this.enrichContext(ctx, mail.getLocale());
+
+    final MimeMessage mimeMessage = this.javaMailSender.createMimeMessage();
+    final MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+    if (mail.getHtmlTemplate() != null) {
+      final Template template = this.freemarkerConfiguration.getTemplate("mail/" + mail.getHtmlTemplate() + ".ftl");
+      final String htmlContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
+      message.setText(htmlContent, true);
+    } else if (mail.getHtmlBody() != null) {
+      message.setText(mail.getHtmlBody(), true);
+    }
+
+    if (mail.getTextTemplate() != null) {
+      final Template template = this.freemarkerConfiguration.getTemplate("mail/" + mail.getTextTemplate() + ".ftl");
+      final String textContent = FreeMarkerTemplateUtils.processTemplateIntoString(template, ctx);
+      message.setText(textContent, false);
+    } else if (mail.getTextBody() != null) {
+      message.setText(mail.getTextBody(), false);
+    }
+
+    message.setFrom(mail.getFrom());
+    if (mail.getReplyTo() != null) {
+      message.setReplyTo(mail.getReplyTo());
+    }
+
+    final String subject = this.messageSource
+      .getMessage(mail.getMailSubject(), new Object[]{}, mail.getMailSubject(), mail.getLocale());
+
+    message.setSubject(subject);
+
+    if (mail.getTo() != null) {
+      message.setTo(mail.getTo().toArray(new InternetAddress[]{}));
+    }
+
+    if (mail.getCc() != null) {
+      message.setCc(mail.getCc().toArray(new InternetAddress[]{}));
+    }
+
+    if (mail.getBcc() != null) {
+      message.setBcc(mail.getBcc().toArray(new InternetAddress[]{}));
+    }
+
+    if (mail.getHighPriority()) {
+      //https://www.chilkatsoft.com/p/p_471.asp
+      mimeMessage.addHeader("X-Priority", "1");
+      mimeMessage.addHeader("X-MSMail-Priority", "High");
+      mimeMessage.addHeader("Importance", "High");
+    }
+
+    if (mail.getAttachments() != null) {
+      for (BlossomMailAttachment attachment : mail.getAttachments()) {
+        attachment.appendTo(message);
+      }
+    }
+
+    try {
+      this.javaMailSender.send(this.filter.filter(message));
+    } catch (Exception e) {
+      LOGGER.error("Error when sending", e);
+    }
+
+    LOGGER.info("Mail with recipient(s) {To: '{}', CC: '{}', BCC: '{}'} sent.",
+      Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.TO)),
+      Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.CC)),
+      Arrays.toString(message.getMimeMessage().getRecipients(Message.RecipientType.BCC)));
+  }
+
+  private void enrichContext(Map<String, Object> ctx, Locale locale) {
+    ctx.put("basePath", this.basePath);
+    ctx.put("message", new MessageResolverMethod(this.messageSource, locale));
+    ctx.put("lang", locale);
+  }
+
+  private class MessageResolverMethod implements TemplateMethodModelEx {
+
+    private MessageSource messageSource;
+    private Locale locale;
+
+    public MessageResolverMethod(MessageSource messageSource, Locale locale) {
+      this.messageSource = messageSource;
+      this.locale = locale;
+    }
+
+    @Override
+    public Object exec(List arguments) throws TemplateModelException {
+      if (arguments.size() != 1) {
+        throw new TemplateModelException("Wrong number of arguments");
+      }
+      String code = ((SimpleScalar) arguments.get(0)).getAsString();
+      if (code == null || code.isEmpty()) {
+        throw new TemplateModelException("Invalid code value '" + code + "'");
+      }
+      return messageSource.getMessage(code, null, locale);
+    }
+  }
+
 }

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
@@ -14,6 +14,7 @@ import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import java.util.*;
+import java.util.stream.Stream;
 
 public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSender {
 
@@ -100,6 +101,7 @@ public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSend
     Preconditions.checkArgument(mail.getCtx() != null);
     Preconditions.checkArgument(mail.getTo() != null && !mail.getTo().isEmpty() || mail.getBcc() != null && !mail.getBcc().isEmpty());
     Preconditions.checkArgument(mail.getMailSubject() != null);
+    Preconditions.checkArgument(Stream.of(mail.getHtmlTemplate(), mail.getHtmlBody(), mail.getTextBody(), mail.getTextTemplate()).anyMatch(Objects::nonNull));
 
     final Map<String, Object> ctx = new HashMap<>(mail.getCtx());
     this.enrichContext(ctx, mail.getLocale());

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/MailSenderImpl.java
@@ -14,6 +14,8 @@ import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSender {
@@ -28,10 +30,12 @@ public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSend
   private final MailFilter filter;
   private final AsyncMailSender asyncMailSender;
   private final InternetAddress from;
+  private final Set<Pattern> filters;
 
   public MailSenderImpl(JavaMailSender javaMailSender, Configuration freemarkerConfiguration,
                         MessageSource messageSource, String basePath, Locale defaultLocale,
-                        MailFilter filter, AsyncMailSender asyncMailSender, InternetAddress from) {
+                        MailFilter filter, AsyncMailSender asyncMailSender, InternetAddress from,
+                        Set<String> filters) {
     Preconditions.checkNotNull(javaMailSender);
     Preconditions.checkNotNull(freemarkerConfiguration);
     Preconditions.checkNotNull(messageSource);
@@ -46,6 +50,7 @@ public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSend
     this.filter = filter;
     this.asyncMailSender = asyncMailSender;
     this.from = from;
+    this.filters = filters.stream().map(Pattern::compile).collect(Collectors.toSet());
   }
 
   private class BlossomMailBuilder extends BlossomMailBuilderImpl {
@@ -93,6 +98,11 @@ public class MailSenderImpl extends DeprecatedMailSenderImpl implements MailSend
     BlossomMailBuilder ret = new BlossomMailBuilder(this);
     ret.locale(defaultLocale);
     ret.from(from);
+    if (filters != null) {
+      for (Pattern filter : filters) {
+        ret.addFilter(filter);
+      }
+    }
     return ret;
   }
 

--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/utils/mail/NoopMailSenderImpl.java
@@ -2,123 +2,34 @@ package com.blossomproject.core.common.utils.mail;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.InputStreamSource;
-
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import org.springframework.scheduling.annotation.AsyncResult;
 
 /**
  * Created by Maël Gargadennnec on 04/05/2017.
  */
-public class NoopMailSenderImpl implements MailSender {
+public class NoopMailSenderImpl extends DeprecatedMailSenderImpl implements MailSender {
   private final static Logger LOGGER = LoggerFactory.getLogger(NoopMailSenderImpl.class);
 
   @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String... mailTo)
-    throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
+  public BlossomMailBuilder builder() {
+    return new BlossomMailBuilderImpl() {
 
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-                       List<File> attachedFiles, String... mailTo) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
-  }
+      @Override
+      public BlossomMail build() {
+        return new BlossomMail() {
 
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
-  }
+          @Override
+          public void send() {
+            LOGGER.warn("A mail with recipient(s) '{To: '{}', CC: '{}', BCC: '{}'}' and subject '{}' was not sent because no java mail sender is configured", to, cc, bcc, mailSubject);
+          }
 
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, String[] mailTo, String[] mailCc, String[] mailBcc, boolean highPriority) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-                       String... mailTo) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), convertToInternetAddress(mailTo));
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress... mailTo)
-    throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-                       List<File> attachedFiles, InternetAddress... mailTo) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, List<File> attachedFiles, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale, String attachmentName, InputStreamSource attachmentInputStreamSource, String attachmentContentType, InternetAddress[] mailTo, InternetAddress[] mailCc, InternetAddress[] mailBcc, boolean highPriority) throws Exception {
-    this.sendMail(htmlTemplate, ctx, mailSubject, Locale.getDefault(), mailTo);
-  }
-
-
-  @Override
-  public void sendMail(String htmlTemplate, Map<String, Object> ctx, String mailSubject, Locale locale,
-                       InternetAddress... mailTo) throws Exception {
-    LOGGER.warn(
-      "A mail with recipient(s) '{}' and subject '{}' was not sent because no java mail sender is configured",
-      Arrays.toString(mailTo), mailSubject);
-  }
-
-  private InternetAddress[] convertToInternetAddress(String[] mails) throws AddressException {
-    if (mails == null) {
-      return null;
-    }
-
-    int i = 0;
-    InternetAddress[] addresses = new InternetAddress[mails.length];
-    for (String mail : mails) {
-      addresses[i++] = new InternetAddress(mail);
-    }
-
-    return addresses;
+          @Override
+          public AsyncResult<BlossomMail> asyncSend() {
+            return new AsyncResult<>(this);
+          }
+        };
+      }
+    };
   }
 
 }

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImplTest.java
@@ -1,0 +1,369 @@
+package com.blossomproject.core.common.utils.mail;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.sun.mail.smtp.SMTPMessage;
+import freemarker.template.Configuration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.MessageSource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.ui.freemarker.FreeMarkerConfigurationFactory;
+
+import javax.mail.Address;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeprecatedMailSenderImplTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private MailSenderImpl mailSender;
+  private JavaMailSender javaMailSender;
+  private Configuration configuration;
+  private MessageSource messageSource;
+  private InternetAddress from;
+  private String basePath;
+  private Set<String> filters;
+  private Locale locale;
+  private MailFilter mailFilter;
+  private AsyncMailSender asyncMailSender;
+
+  @Before
+  public void setUp() throws Exception {
+    this.javaMailSender = mock(JavaMailSender.class);
+    when(javaMailSender.createMimeMessage()).thenReturn(new SMTPMessage((Session) null));
+    doAnswer(invocationOnMock -> {
+      MimeMessage mimeMessage = invocationOnMock.getArgument(0);
+      for (Address address: mimeMessage.getAllRecipients()) {
+        assertNotNull(address);
+      }
+      return null;
+    }).when(javaMailSender).send(any(MimeMessage.class));
+
+    FreeMarkerConfigurationFactory factory = new FreeMarkerConfigurationFactory();
+    factory.setTemplateLoaderPath("/templates");
+    this.configuration = factory.createConfiguration();
+
+    this.messageSource = mock(MessageSource.class);
+    when(messageSource.getMessage(any(), any(), any(), any())).thenReturn("Subject");
+
+    this.mailFilter = mock(MailFilterImpl.class);
+    when(mailFilter.filter(any())).thenReturn(new SMTPMessage((Session) null));
+
+    this.from = new InternetAddress("blossom-test@test.fr");
+    this.basePath = "basePath";
+    this.filters = Sets.newHashSet("*@blossom-project.com");
+    this.locale = Locale.ENGLISH;
+    this.asyncMailSender = mock(AsyncMailSender.class);
+    this.mailSender = new MailSenderImpl(this.javaMailSender, this.configuration,
+      this.messageSource,
+      this.basePath, this.locale, this.mailFilter, asyncMailSender, from);
+  }
+
+  @Test
+  public void should_succeed_instanciate() throws Exception {
+    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+  }
+
+  @Test
+  public void should_fail_instanciate_when_javamailsender_is_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+
+    new MailSenderImpl(null, mock(Configuration.class),
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+  }
+
+  @Test
+  public void should_fail_instanciate_when_configuration_is_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+
+    new MailSenderImpl(mock(JavaMailSender.class), null,
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+  }
+
+
+  @Test
+  public void should_fail_instanciate_when_messagesource_is_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+
+    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
+      null, "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+  }
+
+  @Test
+  public void should_fail_instanciate_when_basepath_is_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+
+    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
+      mock(MessageSource.class), null, this.locale, this.mailFilter, asyncMailSender, from);
+  }
+
+  @Test
+  public void should_fail_instanciate_when_locale_is_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+
+    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
+      mock(MessageSource.class), "basePath", null, this.mailFilter, asyncMailSender, from);
+  }
+
+  @Test
+  public void should_fail_instanciate_when_mailFilter_is_null() throws Exception {
+    thrown.expect(NullPointerException.class);
+
+    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
+      mock(MessageSource.class), "basePath", this.locale, null, asyncMailSender, from);
+  }
+
+
+  @Test
+  public void should_not_send_mail_without_mailtos() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = Maps.newHashMap();
+    String subject = "subject";
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, new InternetAddress[]{});
+  }
+
+  @Test
+  public void should_not_send_mail_without_context() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
+  }
+
+
+  @Test
+  public void should_not_send_mail_without_subject() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = Maps.newHashMap();
+    String subject = null;
+    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
+  }
+
+
+  @Test
+  public void should_not_send_mail_without_context_with_highpriority() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, Lists.newArrayList(), mailTo, null, null, true);
+  }
+
+  @Test
+  public void should_not_send_mail_without_context_with_cc_bcc() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, mailTo, mailTo, mailTo);
+  }
+
+  @Test
+  public void should_not_send_mail_without_context_with_cc_bcc_without_locale() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+  }
+
+  @Test
+  public void should_not_send_mail_without_context_with_inputstream_attachment() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, null, null, null, mailTo, mailTo, null, true);
+  }
+
+
+  @Test
+  public void should_not_send_mail_without_mailtos_string() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = Maps.newHashMap();
+    String subject = "subject";
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, new String[]{});
+  }
+
+  @Test
+  public void should_not_send_mail_without_context_string() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
+  }
+
+
+  @Test
+  public void should_not_send_mail_without_subject_string() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = Maps.newHashMap();
+    String subject = null;
+    String[] mailTo = {"test@test.test"};
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
+  }
+
+
+  @Test
+  public void should_not_send_mail_without_context_with_highpriority_string() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, Lists.newArrayList(), mailTo, null, null, true);
+  }
+
+  @Test
+  public void should_not_send_mail_without_context_with_cc_bcc_string() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, mailTo, mailTo, mailTo);
+  }
+
+  @Test
+  public void should_not_send_mail_without_context_with_cc_bcc_without_locale_string() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+  }
+
+  @Test
+  public void should_not_send_mail_without_context_with_inputstream_attachment_string() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = null;
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, null, null, null, mailTo, mailTo, null, true);
+  }
+
+  @Test
+  public void should_send_mail_with_mailTo() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, null, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_mailCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_mailBCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, mailTo);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_only_mailBCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, (String[])null, (String[])null, mailTo);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_mailTo() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test", "test2@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, null, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_mailCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test", "test2@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_mailBCC() throws Exception {
+    String htmlTemplate = "htmlTemplate";
+    Map<String, Object> parameters = new HashMap<>();
+    String subject = "subject";
+    String[] mailTo = {"test@test.test", "test2@test.test"};
+    this.mailSender.sendMail(htmlTemplate, parameters, subject, (String[])null, (String[])null, mailTo);
+
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  }
+}

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/DeprecatedMailSenderImplTest.java
@@ -19,10 +19,7 @@ import javax.mail.Address;
 import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -74,13 +71,15 @@ public class DeprecatedMailSenderImplTest {
     this.asyncMailSender = mock(AsyncMailSender.class);
     this.mailSender = new MailSenderImpl(this.javaMailSender, this.configuration,
       this.messageSource,
-      this.basePath, this.locale, this.mailFilter, asyncMailSender, from);
+      this.basePath, this.locale, this.mailFilter,
+      asyncMailSender, from, Collections.emptySet());
   }
 
   @Test
   public void should_succeed_instanciate() throws Exception {
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter,
+      asyncMailSender, from, Collections.emptySet());
   }
 
   @Test
@@ -88,7 +87,8 @@ public class DeprecatedMailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(null, mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter,
+      asyncMailSender, from, Collections.emptySet());
   }
 
   @Test
@@ -96,7 +96,8 @@ public class DeprecatedMailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), null,
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter,
+      asyncMailSender, from, Collections.emptySet());
   }
 
 
@@ -105,7 +106,8 @@ public class DeprecatedMailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      null, "basePath", this.locale, this.mailFilter, asyncMailSender, from);
+      null, "basePath", this.locale, this.mailFilter,
+      asyncMailSender, from, Collections.emptySet());
   }
 
   @Test
@@ -113,7 +115,8 @@ public class DeprecatedMailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), null, this.locale, this.mailFilter, asyncMailSender, from);
+      mock(MessageSource.class), null, this.locale, this.mailFilter,
+      asyncMailSender, from, Collections.emptySet());
   }
 
   @Test
@@ -121,7 +124,8 @@ public class DeprecatedMailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", null, this.mailFilter, asyncMailSender, from);
+      mock(MessageSource.class), "basePath", null, this.mailFilter,
+      asyncMailSender, from, Collections.emptySet());
   }
 
   @Test
@@ -129,7 +133,8 @@ public class DeprecatedMailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, null, asyncMailSender, from);
+      mock(MessageSource.class), "basePath", this.locale, null,
+      asyncMailSender, from, Collections.emptySet());
   }
 
 

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailFilterImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailFilterImplTest.java
@@ -30,7 +30,7 @@ public class MailFilterImplTest {
 
   @Before
   public void setUp() throws AddressException {
-    this.mailFilter = new MailFilterImpl(Sets.newHashSet(".*@test.com"), new InternetAddress("Blossom Project <blossom-project@blossom.com>"));
+    this.mailFilter = new MailFilterImpl(Sets.newHashSet(".*@test.com"));
 
   }
 
@@ -80,7 +80,7 @@ public class MailFilterImplTest {
 
   @Test
   public void no_filter() throws Exception {
-    MailFilter mailFilterNoFilter = new MailFilterImpl(null, new InternetAddress("blossom-project@blossom.com"));
+    MailFilter mailFilterNoFilter = new MailFilterImpl(null);
     final MimeMessageHelper helper = new MimeMessageHelper(new MimeMessage((Session) null));
     helper.setTo("test@test.com");
     helper.setCc("filter@filter.com");

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -37,11 +37,12 @@ public class MailSenderImplTest {
   private JavaMailSender javaMailSender;
   private Configuration configuration;
   private MessageSource messageSource;
-  private String from;
+  private InternetAddress from;
   private String basePath;
   private Set<String> filters;
   private Locale locale;
   private MailFilter mailFilter;
+  private AsyncMailSender asyncMailSender;
 
   @Before
   public void setUp() throws Exception {
@@ -65,19 +66,20 @@ public class MailSenderImplTest {
     this.mailFilter = mock(MailFilterImpl.class);
     when(mailFilter.filter(any())).thenReturn(new SMTPMessage((Session) null));
 
-    this.from = "blossom-test@test.fr";
+    this.from = new InternetAddress("blossom-test@test.fr");
     this.basePath = "basePath";
     this.filters = Sets.newHashSet("*@blossom-project.com");
     this.locale = Locale.ENGLISH;
+    this.asyncMailSender = mock(AsyncMailSender.class);
     this.mailSender = new MailSenderImpl(this.javaMailSender, this.configuration,
       this.messageSource,
-      this.basePath, this.locale, this.mailFilter);
+      this.basePath, this.locale, this.mailFilter, asyncMailSender, from);
   }
 
   @Test
   public void should_succeed_instanciate() throws Exception {
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter);
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
   }
 
   @Test
@@ -85,7 +87,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(null, mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter);
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
   }
 
   @Test
@@ -93,7 +95,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), null,
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter);
+      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
   }
 
 
@@ -102,7 +104,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      null, "basePath", this.locale, this.mailFilter);
+      null, "basePath", this.locale, this.mailFilter, asyncMailSender, from);
   }
 
   @Test
@@ -110,7 +112,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), null, this.locale, this.mailFilter);
+      mock(MessageSource.class), null, this.locale, this.mailFilter, asyncMailSender, from);
   }
 
   @Test
@@ -118,7 +120,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", null, this.mailFilter);
+      mock(MessageSource.class), "basePath", null, this.mailFilter, asyncMailSender, from);
   }
 
   @Test
@@ -126,7 +128,7 @@ public class MailSenderImplTest {
     thrown.expect(NullPointerException.class);
 
     new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, null);
+      mock(MessageSource.class), "basePath", this.locale, null, asyncMailSender, from);
   }
 
 

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -110,7 +110,7 @@ public class MailSenderImplTest {
   public void should_send_mail_with_minimum_requirements() throws Exception {
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test Subject").addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test Subject").textBody("Body").addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
     verify(messageSource, atLeastOnce()).getMessage(eq("Test Subject"), any(), any(), any());
   }
@@ -121,7 +121,7 @@ public class MailSenderImplTest {
 
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().addTo(defaultTo).build().send();
+    mailSender.builder().addTo(defaultTo).textBody("Body").build().send();
     verify(mockJavaMailSender, never()).send(any(MimeMessage.class));
   }
 
@@ -131,7 +131,17 @@ public class MailSenderImplTest {
 
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").build().send();
+    verify(mockJavaMailSender, never()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_not_send_mail_with_no_body() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).build().send();
     verify(mockJavaMailSender, never()).send(any(MimeMessage.class));
   }
 
@@ -252,7 +262,7 @@ public class MailSenderImplTest {
       assertEquals("High", mimeMessage.getHeader("Importance")[0]);
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").highPriority(true).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").highPriority(true).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -261,7 +271,7 @@ public class MailSenderImplTest {
     InternetAddress from = new InternetAddress("sender@blossom-project.com", "Test sender");
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getFrom()[0], from));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").from(from).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").from(from).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -270,7 +280,7 @@ public class MailSenderImplTest {
     String from = "sender@blossom-project.com";
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getFrom()[0]).getAddress(), from));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").from(from).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").from(from).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -283,7 +293,7 @@ public class MailSenderImplTest {
       assertEquals(((InternetAddress) mimeMessage.getFrom()[0]).getPersonal(), name);
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").from(from, name).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").from(from, name).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -292,7 +302,7 @@ public class MailSenderImplTest {
     InternetAddress replyTo = new InternetAddress("sender@blossom-project.com", "Test sender");
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getReplyTo()[0], replyTo));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").replyTo(replyTo).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").replyTo(replyTo).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -301,7 +311,7 @@ public class MailSenderImplTest {
     String replyTo = "sender@blossom-project.com";
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getReplyTo()[0]).getAddress(), replyTo));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").replyTo(replyTo).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").replyTo(replyTo).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -314,7 +324,7 @@ public class MailSenderImplTest {
       assertEquals(((InternetAddress) mimeMessage.getReplyTo()[0]).getPersonal(), name);
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").replyTo(replyTo, name).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").replyTo(replyTo, name).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -326,7 +336,7 @@ public class MailSenderImplTest {
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount()));
 
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addAttachment(file).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addAttachment(file).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -339,7 +349,7 @@ public class MailSenderImplTest {
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount()));
 
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addAttachment(file.getName(), is, "text/plain").addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addAttachment(file.getName(), is, "text/plain").addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -350,7 +360,7 @@ public class MailSenderImplTest {
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
 
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addAttachment(attachment).addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addAttachment(attachment).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
     verify(attachment, times(1)).appendTo(any());
   }
@@ -362,7 +372,7 @@ public class MailSenderImplTest {
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
 
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    BlossomMailBuilder builder = mailSender.builder().mailSubject("Test").addTo(defaultTo);
+    BlossomMailBuilder builder = mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo);
     for (BlossomMailAttachment attachment : attachments) {
       builder = builder.addAttachment(attachment);
     }
@@ -377,7 +387,7 @@ public class MailSenderImplTest {
   public void should_send_mail_with_internetAddress_to() throws Exception {
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getRecipients(Message.RecipientType.TO)[0], defaultTo));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -385,7 +395,7 @@ public class MailSenderImplTest {
   public void should_send_mail_with_string_to() throws Exception {
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.TO)[0]).getAddress(), defaultTo.getAddress()));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo.getAddress()).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo.getAddress()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -396,7 +406,7 @@ public class MailSenderImplTest {
       assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.TO)[0]).getPersonal(), defaultTo.getPersonal());
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo.getAddress(), defaultTo.getPersonal()).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo.getAddress(), defaultTo.getPersonal()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -408,7 +418,7 @@ public class MailSenderImplTest {
       assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(additionnalTo));
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addTo(additionnalTo).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addTo(additionnalTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -417,7 +427,7 @@ public class MailSenderImplTest {
     InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getRecipients(Message.RecipientType.CC)[0], cc));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addCc(cc).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -426,7 +436,7 @@ public class MailSenderImplTest {
     InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.CC)[0]).getAddress(), cc.getAddress()));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc.getAddress()).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addCc(cc.getAddress()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -438,7 +448,7 @@ public class MailSenderImplTest {
       assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.CC)[0]).getPersonal(), cc.getPersonal());
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc.getAddress(), cc.getPersonal()).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addCc(cc.getAddress(), cc.getPersonal()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -451,7 +461,7 @@ public class MailSenderImplTest {
       assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(additionnalCc));
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc).addCc(additionnalCc).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addCc(cc).addCc(additionnalCc).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -460,7 +470,7 @@ public class MailSenderImplTest {
     InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getRecipients(Message.RecipientType.BCC)[0], bcc));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addBcc(bcc).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -469,7 +479,7 @@ public class MailSenderImplTest {
     InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
     JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.BCC)[0]).getAddress(), bcc.getAddress()));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc.getAddress()).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addBcc(bcc.getAddress()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -481,7 +491,7 @@ public class MailSenderImplTest {
       assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.BCC)[0]).getPersonal(), bcc.getPersonal());
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc.getAddress(), bcc.getPersonal()).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addBcc(bcc.getAddress(), bcc.getPersonal()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -494,7 +504,7 @@ public class MailSenderImplTest {
       assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(additionnalBcc));
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc).addBcc(additionnalBcc).build().send();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).addBcc(bcc).addBcc(additionnalBcc).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
@@ -512,7 +522,7 @@ public class MailSenderImplTest {
       assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(filteredAddress));
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test")
+    mailSender.builder().mailSubject("Test").textBody("Body")
       .addFilter(filter)
       .addTo(keptAddress).addCc(keptAddress).addBcc(keptAddress)
       .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
@@ -534,7 +544,7 @@ public class MailSenderImplTest {
       assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(filteredAddress));
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test")
+    mailSender.builder().mailSubject("Test").textBody("Body")
       .addFilter(filter)
       .addTo(keptAddress).addCc(keptAddress).addBcc(keptAddress)
       .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
@@ -557,7 +567,7 @@ public class MailSenderImplTest {
       assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(filteredAddress));
     });
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test")
+    mailSender.builder().mailSubject("Test").textBody("Body")
       .addFilter(filter).addFilter(filter2)
       .addTo(keptAddress).addCc(keptAddress).addBcc(keptAddress)
       .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
@@ -571,7 +581,7 @@ public class MailSenderImplTest {
     InternetAddress filteredAddress = new InternetAddress("filtered@blossom-project.com");
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test")
+    mailSender.builder().mailSubject("Test").textBody("Body")
       .addFilter(filter)
       .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
       .build().send();
@@ -582,7 +592,7 @@ public class MailSenderImplTest {
   public void should_async_send_use_asyncMailSender() throws Exception {
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).build().asyncSend();
+    mailSender.builder().mailSubject("Test").textBody("Body").addTo(defaultTo).build().asyncSend();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
     verify(asyncMailSender, times(1)).asyncSend(any());
   }

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -1,10 +1,8 @@
 package com.blossomproject.core.common.utils.mail;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.sun.mail.smtp.SMTPMessage;
 import freemarker.template.Configuration;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,19 +10,25 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.context.MessageSource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamSource;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.ui.freemarker.FreeMarkerConfigurationFactory;
 
-import javax.mail.Address;
+import javax.mail.Message;
 import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import javax.mail.internet.MimeMultipart;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -33,29 +37,20 @@ public class MailSenderImplTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-  private MailSenderImpl mailSender;
-  private JavaMailSender javaMailSender;
+
   private Configuration configuration;
   private MessageSource messageSource;
   private InternetAddress from;
+  private InternetAddress defaultTo;
   private String basePath;
-  private Set<String> filters;
   private Locale locale;
   private MailFilter mailFilter;
   private AsyncMailSender asyncMailSender;
 
+  private String randomString = RandomStringUtils.random(10);
+
   @Before
   public void setUp() throws Exception {
-    this.javaMailSender = mock(JavaMailSender.class);
-    when(javaMailSender.createMimeMessage()).thenReturn(new SMTPMessage((Session) null));
-    doAnswer(invocationOnMock -> {
-      MimeMessage mimeMessage = invocationOnMock.getArgument(0);
-      for (Address address: mimeMessage.getAllRecipients()) {
-        assertNotNull(address);
-      }
-      return null;
-    }).when(javaMailSender).send(any(MimeMessage.class));
-
     FreeMarkerConfigurationFactory factory = new FreeMarkerConfigurationFactory();
     factory.setTemplateLoaderPath("/templates");
     this.configuration = factory.createConfiguration();
@@ -64,305 +59,545 @@ public class MailSenderImplTest {
     when(messageSource.getMessage(any(), any(), any(), any())).thenReturn("Subject");
 
     this.mailFilter = mock(MailFilterImpl.class);
-    when(mailFilter.filter(any())).thenReturn(new SMTPMessage((Session) null));
+    when(mailFilter.filter(any())).thenAnswer(invocation -> (((MimeMessageHelper) invocation.getArgument(0)).getMimeMessage()));
 
-    this.from = new InternetAddress("blossom-test@test.fr");
+    this.from = new InternetAddress("blossom-test@blossom-project.com");
+    this.defaultTo = new InternetAddress("test@blossom-project.com");
     this.basePath = "basePath";
-    this.filters = Sets.newHashSet("*@blossom-project.com");
     this.locale = Locale.ENGLISH;
     this.asyncMailSender = mock(AsyncMailSender.class);
-    this.mailSender = new MailSenderImpl(this.javaMailSender, this.configuration,
+  }
+
+  private interface Consumer<T> {
+    void accept(T t) throws Exception;
+  }
+
+  private JavaMailSender mockJavaMailSender() {
+    JavaMailSender javaMailSender = mock(JavaMailSender.class);
+    when(javaMailSender.createMimeMessage()).thenReturn(new SMTPMessage((Session) null));
+    return javaMailSender;
+  }
+
+  private JavaMailSender mockJavaMailSender(Consumer<SMTPMessage> send) {
+    JavaMailSender javaMailSender = mock(JavaMailSender.class);
+    when(javaMailSender.createMimeMessage()).thenReturn(new SMTPMessage((Session) null));
+    doAnswer(invocationOnMock -> {
+      SMTPMessage mimeMessage = invocationOnMock.getArgument(0);
+      send.accept(mimeMessage);
+      return null;
+    }).when(javaMailSender).send(any(MimeMessage.class));
+    return javaMailSender;
+  }
+
+  private MailSender testedMailSender(JavaMailSender javaMailSender) {
+    return new MailSenderImpl(
+      javaMailSender,
+      this.configuration,
       this.messageSource,
-      this.basePath, this.locale, this.mailFilter, asyncMailSender, from);
+      this.basePath,
+      this.locale,
+      this.mailFilter,
+      asyncMailSender,
+      from);
+  }
+
+  /*
+   * Tests
+   */
+
+  @Test
+  public void should_send_mail_with_minimum_requirements() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_succeed_instanciate() throws Exception {
-    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
-  }
-
-  @Test
-  public void should_fail_instanciate_when_javamailsender_is_null() throws Exception {
-    thrown.expect(NullPointerException.class);
-
-    new MailSenderImpl(null, mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
-  }
-
-  @Test
-  public void should_fail_instanciate_when_configuration_is_null() throws Exception {
-    thrown.expect(NullPointerException.class);
-
-    new MailSenderImpl(mock(JavaMailSender.class), null,
-      mock(MessageSource.class), "basePath", this.locale, this.mailFilter, asyncMailSender, from);
-  }
-
-
-  @Test
-  public void should_fail_instanciate_when_messagesource_is_null() throws Exception {
-    thrown.expect(NullPointerException.class);
-
-    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      null, "basePath", this.locale, this.mailFilter, asyncMailSender, from);
-  }
-
-  @Test
-  public void should_fail_instanciate_when_basepath_is_null() throws Exception {
-    thrown.expect(NullPointerException.class);
-
-    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), null, this.locale, this.mailFilter, asyncMailSender, from);
-  }
-
-  @Test
-  public void should_fail_instanciate_when_locale_is_null() throws Exception {
-    thrown.expect(NullPointerException.class);
-
-    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", null, this.mailFilter, asyncMailSender, from);
-  }
-
-  @Test
-  public void should_fail_instanciate_when_mailFilter_is_null() throws Exception {
-    thrown.expect(NullPointerException.class);
-
-    new MailSenderImpl(mock(JavaMailSender.class), mock(Configuration.class),
-      mock(MessageSource.class), "basePath", this.locale, null, asyncMailSender, from);
-  }
-
-
-  @Test
-  public void should_not_send_mail_without_mailtos() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = Maps.newHashMap();
-    String subject = "subject";
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, new InternetAddress[]{});
-  }
-
-  @Test
-  public void should_not_send_mail_without_context() throws Exception {
+  public void should_not_send_mail_with_no_subject() throws Exception {
     thrown.expect(IllegalArgumentException.class);
 
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, never()).send(any(MimeMessage.class));
   }
 
-
   @Test
-  public void should_not_send_mail_without_subject() throws Exception {
+  public void should_not_send_mail_with_no_recipients() throws Exception {
     thrown.expect(IllegalArgumentException.class);
 
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = Maps.newHashMap();
-    String subject = null;
-    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
-  }
-
-
-  @Test
-  public void should_not_send_mail_without_context_with_highpriority() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, Lists.newArrayList(), mailTo, null, null, true);
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").build().send();
+    verify(mockJavaMailSender, never()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_not_send_mail_without_context_with_cc_bcc() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, mailTo, mailTo, mailTo);
+  public void should_send_mail_with_text_template() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains("Text template"));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").textTemplate("textTemplate").addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_not_send_mail_without_context_with_cc_bcc_without_locale() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+  public void should_send_mail_with_text_body() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains(randomString));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").textBody(randomString).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_not_send_mail_without_context_with_inputstream_attachment() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    InternetAddress[] mailTo = {new InternetAddress("test@test.test")};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, null, null, null, mailTo, mailTo, null, true);
-  }
-
-
-  @Test
-  public void should_not_send_mail_without_mailtos_string() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = Maps.newHashMap();
-    String subject = "subject";
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, new String[]{});
+  public void should_send_mail_with_html_template() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains("Test template"));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").htmlTemplate("htmlTemplate").addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_not_send_mail_without_context_string() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
-  }
-
-
-  @Test
-  public void should_not_send_mail_without_subject_string() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = Maps.newHashMap();
-    String subject = null;
-    String[] mailTo = {"test@test.test"};
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo);
-  }
-
-
-  @Test
-  public void should_not_send_mail_without_context_with_highpriority_string() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, Lists.newArrayList(), mailTo, null, null, true);
+  public void should_send_mail_with_html_body() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains(randomString));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").htmlBody(randomString).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_not_send_mail_without_context_with_cc_bcc_string() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, mailTo, mailTo, mailTo);
+  public void should_send_mail_with_text_context() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains("variable " + randomString));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").textTemplate("textTemplateWithContext").addContext("variable", randomString).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_not_send_mail_without_context_with_cc_bcc_without_locale_string() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
+  public void should_send_mail_with_html_context() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains("variable " + randomString));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    Map<String, Object> ctx = new HashMap<>();
+    ctx.put("variable", randomString);
+    mailSender.builder().mailSubject("Test").htmlTemplate("textTemplateWithContext").addContext(ctx).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_not_send_mail_without_context_with_inputstream_attachment_string() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = null;
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, this.locale, null, null, null, mailTo, mailTo, null, true);
+  public void should_send_mail_with_text_translation() throws Exception {
+    when(messageSource.getMessage(eq("test"), any(), any())).thenReturn(randomString);
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains("translated " + randomString));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").textTemplate("textTemplateWithTranslation").addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_send_mail_with_mailTo() throws Exception {
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = new HashMap<>();
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, null, null);
-
-    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  public void should_send_mail_with_html_translation_and_french_locale() throws Exception {
+    when(messageSource.getMessage(eq("test"), any(), eq(Locale.FRENCH))).thenReturn(randomString);
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertNotNull(mimeMessage.getContent());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      ((MimeMultipart) mimeMessage.getContent()).writeTo(os);
+      assertTrue(os.toString().contains("translated " + randomString));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").htmlTemplate("textTemplateWithTranslation").locale(Locale.FRENCH).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_send_mail_with_mailCC() throws Exception {
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = new HashMap<>();
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
-
-    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  public void should_send_mail_with_high_priority() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      //https://www.chilkatsoft.com/p/p_471.asp
+      assertEquals("1", mimeMessage.getHeader("X-Priority")[0]);
+      assertEquals("High", mimeMessage.getHeader("X-MSMail-Priority")[0]);
+      assertEquals("High", mimeMessage.getHeader("Importance")[0]);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").highPriority(true).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_send_mail_with_mailBCC() throws Exception {
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = new HashMap<>();
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, mailTo);
-
-    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  public void should_send_mail_with_internetAddress_sender() throws Exception {
+    InternetAddress from = new InternetAddress("sender@blossom-project.com", "Test sender");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(mimeMessage.getFrom()[0], from);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").from(from).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_send_mail_with_only_mailBCC() throws Exception {
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = new HashMap<>();
-    String subject = "subject";
-    String[] mailTo = {"test@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, (String[])null, (String[])null, mailTo);
-
-    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  public void should_send_mail_with_string_sender() throws Exception {
+    String from = "sender@blossom-project.com";
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getFrom()[0]).getAddress(), from);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").from(from).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_send_mail_with_multiple_mailTo() throws Exception {
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = new HashMap<>();
-    String subject = "subject";
-    String[] mailTo = {"test@test.test", "test2@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, null, null);
-
-    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  public void should_send_mail_with_string_sender_with_personnal() throws Exception {
+    String from = "sender@blossom-project.com";
+    String name = "Sender";
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getFrom()[0]).getAddress(), from);
+      assertEquals(((InternetAddress) mimeMessage.getFrom()[0]).getPersonal(), name);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").from(from, name).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_send_mail_with_multiple_mailCC() throws Exception {
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = new HashMap<>();
-    String subject = "subject";
-    String[] mailTo = {"test@test.test", "test2@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, mailTo, mailTo, null);
-
-    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  public void should_send_mail_with_internetAddress_replyTo() throws Exception {
+    InternetAddress replyTo = new InternetAddress("sender@blossom-project.com", "Test sender");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(mimeMessage.getReplyTo()[0], replyTo);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").replyTo(replyTo).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
 
   @Test
-  public void should_send_mail_with_multiple_mailBCC() throws Exception {
-    String htmlTemplate = "htmlTemplate";
-    Map<String, Object> parameters = new HashMap<>();
-    String subject = "subject";
-    String[] mailTo = {"test@test.test", "test2@test.test"};
-    this.mailSender.sendMail(htmlTemplate, parameters, subject, (String[])null, (String[])null, mailTo);
-
-    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+  public void should_send_mail_with_string_replyTo() throws Exception {
+    String replyTo = "sender@blossom-project.com";
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getReplyTo()[0]).getAddress(), replyTo);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").replyTo(replyTo).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
   }
+
+  @Test
+  public void should_send_mail_with_string_replyTo_with_personnal() throws Exception {
+    String replyTo = "sender@blossom-project.com";
+    String name = "Sender";
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getReplyTo()[0]).getAddress(), replyTo);
+      assertEquals(((InternetAddress) mimeMessage.getReplyTo()[0]).getPersonal(), name);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").replyTo(replyTo, name).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_file_attachment() throws Exception {
+    URL resource = MailSenderImplTest.class.getResource("/templates/mail/textTemplate.ftl");
+    File file = Paths.get(resource.toURI()).toFile();
+
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount());
+    });
+
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addAttachment(file).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_input_stream_attachment() throws Exception {
+    URL resource = MailSenderImplTest.class.getResource("/templates/mail/textTemplate.ftl");
+    File file = Paths.get(resource.toURI()).toFile();
+    InputStreamSource is = new FileSystemResource(file);
+
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount());
+    });
+
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addAttachment(file.getName(), is, "text/plain").addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_blossom_attachment() throws Exception {
+    BlossomMailAttachment attachment = mock(BlossomMailAttachment.class);
+
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addAttachment(attachment).addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+    verify(attachment, times(1)).appendTo(any());
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_attachments() throws Exception {
+    List<BlossomMailAttachment> attachments = Arrays.asList(mock(BlossomMailAttachment.class), mock(BlossomMailAttachment.class));
+
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    BlossomMailBuilder builder = mailSender.builder().mailSubject("Test").addTo(defaultTo);
+    for (BlossomMailAttachment attachment : attachments) {
+      builder = builder.addAttachment(attachment);
+    }
+    builder.build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+    for (BlossomMailAttachment attachment : attachments) {
+      verify(attachment, times(1)).appendTo(any());
+    }
+  }
+
+  @Test
+  public void should_send_mail_with_internetAddress_to() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(mimeMessage.getRecipients(Message.RecipientType.TO)[0], defaultTo);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_string_to() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.TO)[0]).getAddress(), defaultTo.getAddress());
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo.getAddress()).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_string_to_with_personnal() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.TO)[0]).getAddress(), defaultTo.getAddress());
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.TO)[0]).getPersonal(), defaultTo.getPersonal());
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo.getAddress(), defaultTo.getPersonal()).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_to() throws Exception {
+    InternetAddress additionnalTo = new InternetAddress("another@blossom-project.com", "Another");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(defaultTo));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(additionnalTo));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addTo(additionnalTo).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_internetAddress_cc() throws Exception {
+    InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(mimeMessage.getRecipients(Message.RecipientType.CC)[0], cc);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_string_cc() throws Exception {
+    InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.CC)[0]).getAddress(), cc.getAddress());
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc.getAddress()).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_string_cc_with_personnal() throws Exception {
+    InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.CC)[0]).getAddress(), cc.getAddress());
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.CC)[0]).getPersonal(), cc.getPersonal());
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc.getAddress(), cc.getPersonal()).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_cc() throws Exception {
+    InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
+    InternetAddress additionnalCc = new InternetAddress("another@blossom-project.com", "Another");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(cc));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(additionnalCc));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc).addCc(additionnalCc).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_internetAddress_bcc() throws Exception {
+    InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(mimeMessage.getRecipients(Message.RecipientType.BCC)[0], bcc);
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_string_bcc() throws Exception {
+    InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.BCC)[0]).getAddress(), bcc.getAddress());
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc.getAddress()).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_string_bcc_with_personnal() throws Exception {
+    InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.BCC)[0]).getAddress(), bcc.getAddress());
+      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.BCC)[0]).getPersonal(), bcc.getPersonal());
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc.getAddress(), bcc.getPersonal()).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_bcc() throws Exception {
+    InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
+    InternetAddress additionnalBcc = new InternetAddress("another@blossom-project.com", "Another");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(bcc));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(additionnalBcc));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc).addBcc(additionnalBcc).build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_filter_string() throws Exception {
+    String filter = "kept.*";
+    InternetAddress keptAddress = new InternetAddress("kept@blossom-project.com");
+    InternetAddress filteredAddress = new InternetAddress("filtered@blossom-project.com");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(keptAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(keptAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(keptAddress));
+      assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(filteredAddress));
+      assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(filteredAddress));
+      assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(filteredAddress));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test")
+      .addFilter(filter)
+      .addTo(keptAddress).addCc(keptAddress).addBcc(keptAddress)
+      .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
+      .build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_filter_pattern() throws Exception {
+    Pattern filter = Pattern.compile("kept.*");
+    InternetAddress keptAddress = new InternetAddress("kept@blossom-project.com");
+    InternetAddress filteredAddress = new InternetAddress("filtered@blossom-project.com");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(keptAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(keptAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(keptAddress));
+      assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(filteredAddress));
+      assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(filteredAddress));
+      assertFalse(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(filteredAddress));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test")
+      .addFilter(filter)
+      .addTo(keptAddress).addCc(keptAddress).addBcc(keptAddress)
+      .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
+      .build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test
+  public void should_send_mail_with_multiple_filters() throws Exception {
+    String filter = "kept.*";
+    String filter2 = ".*@blossom-project.com";
+    InternetAddress keptAddress = new InternetAddress("kept@test.blossom-project.com");
+    InternetAddress filteredAddress = new InternetAddress("not-filtered@blossom-project.com");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(keptAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(keptAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(keptAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.TO)).contains(filteredAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.CC)).contains(filteredAddress));
+      assertTrue(Arrays.asList(mimeMessage.getRecipients(Message.RecipientType.BCC)).contains(filteredAddress));
+    });
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test")
+      .addFilter(filter).addFilter(filter2)
+      .addTo(keptAddress).addCc(keptAddress).addBcc(keptAddress)
+      .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
+      .build().send();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+  }
+
+  @Test(expected = Exception.class)
+  public void should_not_send_mail_with_recipients_filtered() throws Exception {
+    String filter = ".*@test.blossom-project.com";
+    InternetAddress filteredAddress = new InternetAddress("filtered@blossom-project.com");
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test")
+      .addFilter(filter)
+      .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
+      .build().send();
+    verify(mockJavaMailSender, never()).send(any(MimeMessage.class));
+  }
+
 }

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -65,7 +65,7 @@ public class MailSenderImplTest {
     this.defaultTo = new InternetAddress("test@blossom-project.com");
     this.basePath = "basePath";
     this.locale = Locale.ENGLISH;
-    this.asyncMailSender = mock(AsyncMailSender.class);
+    this.asyncMailSender = spy(new AsyncMailSenderImpl());
   }
 
   private interface Consumer<T> {
@@ -257,9 +257,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_internetAddress_sender() throws Exception {
     InternetAddress from = new InternetAddress("sender@blossom-project.com", "Test sender");
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(mimeMessage.getFrom()[0], from);
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getFrom()[0], from));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").from(from).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -268,9 +266,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_string_sender() throws Exception {
     String from = "sender@blossom-project.com";
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(((InternetAddress) mimeMessage.getFrom()[0]).getAddress(), from);
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getFrom()[0]).getAddress(), from));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").from(from).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -292,9 +288,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_internetAddress_replyTo() throws Exception {
     InternetAddress replyTo = new InternetAddress("sender@blossom-project.com", "Test sender");
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(mimeMessage.getReplyTo()[0], replyTo);
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getReplyTo()[0], replyTo));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").replyTo(replyTo).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -303,9 +297,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_string_replyTo() throws Exception {
     String replyTo = "sender@blossom-project.com";
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(((InternetAddress) mimeMessage.getReplyTo()[0]).getAddress(), replyTo);
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getReplyTo()[0]).getAddress(), replyTo));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").replyTo(replyTo).addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -329,9 +321,7 @@ public class MailSenderImplTest {
     URL resource = MailSenderImplTest.class.getResource("/templates/mail/textTemplate.ftl");
     File file = Paths.get(resource.toURI()).toFile();
 
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount());
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount()));
 
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addAttachment(file).addTo(defaultTo).build().send();
@@ -344,9 +334,7 @@ public class MailSenderImplTest {
     File file = Paths.get(resource.toURI()).toFile();
     InputStreamSource is = new FileSystemResource(file);
 
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount());
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(2, ((MimeMultipart) mimeMessage.getContent()).getCount()));
 
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addAttachment(file.getName(), is, "text/plain").addTo(defaultTo).build().send();
@@ -385,9 +373,7 @@ public class MailSenderImplTest {
 
   @Test
   public void should_send_mail_with_internetAddress_to() throws Exception {
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(mimeMessage.getRecipients(Message.RecipientType.TO)[0], defaultTo);
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getRecipients(Message.RecipientType.TO)[0], defaultTo));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -395,9 +381,7 @@ public class MailSenderImplTest {
 
   @Test
   public void should_send_mail_with_string_to() throws Exception {
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.TO)[0]).getAddress(), defaultTo.getAddress());
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.TO)[0]).getAddress(), defaultTo.getAddress()));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addTo(defaultTo.getAddress()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -429,9 +413,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_internetAddress_cc() throws Exception {
     InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(mimeMessage.getRecipients(Message.RecipientType.CC)[0], cc);
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getRecipients(Message.RecipientType.CC)[0], cc));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -440,9 +422,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_string_cc() throws Exception {
     InternetAddress cc = new InternetAddress("cc@blossom-project.com", "CC");
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.CC)[0]).getAddress(), cc.getAddress());
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.CC)[0]).getAddress(), cc.getAddress()));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addTo(defaultTo).addCc(cc.getAddress()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -476,9 +456,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_internetAddress_bcc() throws Exception {
     InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(mimeMessage.getRecipients(Message.RecipientType.BCC)[0], bcc);
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(mimeMessage.getRecipients(Message.RecipientType.BCC)[0], bcc));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -487,9 +465,7 @@ public class MailSenderImplTest {
   @Test
   public void should_send_mail_with_string_bcc() throws Exception {
     InternetAddress bcc = new InternetAddress("bcc@blossom-project.com", "BCC");
-    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> {
-      assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.BCC)[0]).getAddress(), bcc.getAddress());
-    });
+    JavaMailSender mockJavaMailSender = mockJavaMailSender(mimeMessage -> assertEquals(((InternetAddress) mimeMessage.getRecipients(Message.RecipientType.BCC)[0]).getAddress(), bcc.getAddress()));
     MailSender mailSender = testedMailSender(mockJavaMailSender);
     mailSender.builder().mailSubject("Test").addTo(defaultTo).addBcc(bcc.getAddress()).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
@@ -598,6 +574,15 @@ public class MailSenderImplTest {
       .addTo(filteredAddress).addCc(filteredAddress).addBcc(filteredAddress)
       .build().send();
     verify(mockJavaMailSender, never()).send(any(MimeMessage.class));
+  }
+
+  @Test()
+  public void should_async_send_use_asyncMailSender() throws Exception {
+    JavaMailSender mockJavaMailSender = mockJavaMailSender();
+    MailSender mailSender = testedMailSender(mockJavaMailSender);
+    mailSender.builder().mailSubject("Test").addTo(defaultTo).build().asyncSend();
+    verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+    verify(asyncMailSender, times(1)).asyncSend(any());
   }
 
 }

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -109,8 +109,9 @@ public class MailSenderImplTest {
   public void should_send_mail_with_minimum_requirements() throws Exception {
     JavaMailSender mockJavaMailSender = mockJavaMailSender();
     MailSender mailSender = testedMailSender(mockJavaMailSender);
-    mailSender.builder().mailSubject("Test").addTo(defaultTo).build().send();
+    mailSender.builder().mailSubject("Test Subject").addTo(defaultTo).build().send();
     verify(mockJavaMailSender, atLeastOnce()).send(any(MimeMessage.class));
+    verify(messageSource, atLeastOnce()).getMessage(eq("Test Subject"), any(), any(), any());
   }
 
   @Test

--- a/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
+++ b/blossom-core/blossom-core-common/src/test/java/com/blossomproject/core/common/utils/mail/MailSenderImplTest.java
@@ -98,7 +98,8 @@ public class MailSenderImplTest {
       this.locale,
       this.mailFilter,
       asyncMailSender,
-      from);
+      from,
+      Collections.emptySet());
   }
 
   /*

--- a/blossom-core/blossom-core-common/src/test/resources/templates/mail/textTemplate.ftl
+++ b/blossom-core/blossom-core-common/src/test/resources/templates/mail/textTemplate.ftl
@@ -1,0 +1,1 @@
+Text template

--- a/blossom-core/blossom-core-common/src/test/resources/templates/mail/textTemplateWithContext.ftl
+++ b/blossom-core/blossom-core-common/src/test/resources/templates/mail/textTemplateWithContext.ftl
@@ -1,0 +1,1 @@
+Text template with variable ${variable}

--- a/blossom-core/blossom-core-common/src/test/resources/templates/mail/textTemplateWithTranslation.ftl
+++ b/blossom-core/blossom-core-common/src/test/resources/templates/mail/textTemplateWithTranslation.ftl
@@ -1,0 +1,1 @@
+Text template with translated ${message("test")}

--- a/blossom-core/blossom-core-user/src/main/java/com/blossomproject/core/user/UserMailServiceImpl.java
+++ b/blossom-core/blossom-core-user/src/main/java/com/blossomproject/core/user/UserMailServiceImpl.java
@@ -2,9 +2,6 @@ package com.blossomproject.core.user;
 
 import com.blossomproject.core.common.utils.mail.MailSender;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import java.util.Map;
-import javax.mail.internet.InternetAddress;
 
 public class UserMailServiceImpl implements UserMailService {
 
@@ -20,11 +17,15 @@ public class UserMailServiceImpl implements UserMailService {
     Preconditions.checkNotNull(user);
     Preconditions.checkNotNull(token);
 
-    Map<String, Object> ctx = Maps.newHashMap();
-    ctx.put("user", user);
-    ctx.put("token", token);
-
-    this.mailSender.sendMail("user-activation", ctx, "activation.subject", user.getLocale(), new InternetAddress(user.getEmail(), user.getFirstname()+" "+user.getLastname()));
+    this.mailSender.builder()
+      .htmlTemplate("user-activation")
+      .addContext("user", user)
+      .addContext("token", token)
+      .mailSubject("activation.subject")
+      .locale(user.getLocale())
+      .addTo(user.getEmail(), user.getFirstname() + " " + user.getLastname())
+      .build()
+      .asyncSend();
   }
 
   @Override
@@ -32,10 +33,14 @@ public class UserMailServiceImpl implements UserMailService {
     Preconditions.checkNotNull(user);
     Preconditions.checkNotNull(token);
 
-    Map<String, Object> ctx = Maps.newHashMap();
-    ctx.put("user", user);
-    ctx.put("token", token);
-
-    this.mailSender.sendMail("user-change-password", ctx, "change.password.subject", user.getLocale(), new InternetAddress(user.getEmail(), user.getFirstname()+" "+user.getLastname()));
+    this.mailSender.builder()
+      .htmlTemplate("user-change-password")
+      .addContext("user", user)
+      .addContext("token", token)
+      .mailSubject("change.password.subject")
+      .locale(user.getLocale())
+      .addTo(user.getEmail(), user.getFirstname() + " " + user.getLastname())
+      .build()
+      .asyncSend();
   }
 }

--- a/blossom-core/blossom-core-user/src/test/java/com/blossomproject/core/user/UserMailServiceImplTest.java
+++ b/blossom-core/blossom-core-user/src/test/java/com/blossomproject/core/user/UserMailServiceImplTest.java
@@ -1,14 +1,9 @@
 package com.blossomproject.core.user;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.blossomproject.core.common.utils.action_token.ActionTokenService;
+import com.blossomproject.core.common.utils.mail.BlossomMail;
+import com.blossomproject.core.common.utils.mail.BlossomMailBuilderImpl;
 import com.blossomproject.core.common.utils.mail.MailSender;
-import java.util.Locale;
-import javax.mail.internet.InternetAddress;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -18,7 +13,9 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
-;
+import java.util.Locale;
+
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserMailServiceImplTest {
@@ -36,19 +33,29 @@ public class UserMailServiceImplTest {
   @InjectMocks
   private UserMailServiceImpl userMailService;
 
+  private BlossomMail setupBlossomMail() {
+    BlossomMail mail = mock(BlossomMail.class);
+    when(mailSender.builder()).thenReturn(new BlossomMailBuilderImpl() {
+      @Override
+      public BlossomMail build() {
+        return mail;
+      }
+    });
+    return mail;
+  }
+
   @Test
   public void test_send_change_password_email_user_not_null_token_not_null() throws Exception {
     UserDTO userDTO = new UserDTO();
     userDTO.setLocale(Locale.FRANCE);
     userDTO.setEmail("test@test.test");
-    userMailService.sendChangePasswordEmail(userDTO , "token !");
 
-    verify(mailSender, times(1))
-      .sendMail(anyString(),
-        any(),
-        anyString(),
-        any(Locale.class),
-        any(InternetAddress.class));
+    BlossomMail mail = setupBlossomMail();
+
+    userMailService.sendChangePasswordEmail(userDTO, "token !");
+
+    verify(mailSender, times(1)).builder();
+    verify(mail, times(1)).asyncSend();
   }
 
   @Test
@@ -73,11 +80,12 @@ public class UserMailServiceImplTest {
     userDTO.setLocale(Locale.FRANCE);
     userDTO.setEmail("test@test.test");
 
+    BlossomMail mail = setupBlossomMail();
+
     userMailService.sendAccountCreationEmail(userDTO, "token !");
 
-    verify(mailSender, times(1))
-      .sendMail(anyString(), any(),
-        anyString(), any(Locale.class), any(InternetAddress.class));
+    verify(mailSender, times(1)).builder();
+    verify(mail, times(1)).asyncSend();
   }
 
   @Test


### PR DESCRIPTION
Rework MailSender's interface.

The goals of this new interface avoid doubling the number of methods for each new functionality, like what happened with addresses going from `String` to `InternetAddress` ; as well as being easier to work with by only using the methods you need.

How it works:
- MailSender is now a simple interface with only one method: create BlossomMailBuilder
- BlossomMailBuilder is an interface for mail parameters, including subject, body, sender, recipients, filters, attachments...
- BlossomMail is an interface once a mail has been built, to send it off synchronously or asynchronously
- BlossomMail's default implementation stores parameters, and passes them back to the MailSender's default implementation

Note on async: since the "send" method is now not part of the MailSender but of an object created from it (and not managed by Spring, so no AOP available there), another service (AsyncMailSender) is used to benefit from Spring's `@Async`.  
The default AsyncMailSender implementation simply calls the synchronous `send` method benefiting from Spring's Async.

Deprecated by this PR:
- All 16 methods from MailSender ; moved to a `DeprecatedMailSender` interface pending deletion
- MailFilter's interface, since it is replaced by filters on the builder directly.

Still undecided:
- Since the MailFilter was the only way to access the underlying MimeMessageHelper, it has been abused to implement functionalities not available in the MailSender in projects using Blossom. Should a "catch all" functionality be added in the Builder's interface to account for such needs? Something like:
  ```
  BlossomMailBuilder addFinalizer(Consumer<MimeMessageHelper> finalizer);
  ```
  and have the finalizer be called right before sending the email.
- Even without having a generic "finalizer" parameter, should all functionalities of the MimeMessageHelper be available in the BlossomMailBuilder? Compared to the previous MailSender functionalities, this PR already added "reply to" ; but it is still missing stuff like setting sent date, finer priority setting, finer body management, inline elements...
- String -> InternetAddress methods in BlossomMailBuilder propagate their exceptions as is, not sure if they should be hidden (as RuntimeExceptions) to avoid being bound to these exceptions in the interface in the future