### PR TITLE
Java 11 compatibility & Spring boot 2.1

### DIFF
--- a/blossom-core/blossom-core-common/pom.xml
+++ b/blossom-core/blossom-core-common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.blossom-project</groupId>
@@ -87,6 +87,10 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
   </dependencies>
 

--- a/blossom-core/blossom-core-validation/pom.xml
+++ b/blossom-core/blossom-core-validation/pom.xml
@@ -24,6 +24,10 @@
       <artifactId>validation-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/blossom-modules/blossom-module-bpmn/pom.xml
+++ b/blossom-modules/blossom-module-bpmn/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.camunda.bpm.extension.springboot</groupId>
+      <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
     </dependency>
   </dependencies>

--- a/blossom-parent/pom.xml
+++ b/blossom-parent/pom.xml
@@ -26,7 +26,7 @@
     <bouncycastle.version>1.59</bouncycastle.version>
     <liquibase.version>3.5.3</liquibase.version>
     <camunda.version>3.2.0</camunda.version>
-    <tika.version>1.19.1</tika.version>
+    <tika.version>1.20</tika.version>
     <powermock.version>1.7.3</powermock.version>
     <elasticsearch.version>2.4.6</elasticsearch.version>
     <commons-lang3.version>3.7</commons-lang3.version>

--- a/blossom-parent/pom.xml
+++ b/blossom-parent/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <springboot.version>2.0.6.RELEASE</springboot.version>
+    <springboot.version>2.1.1.RELEASE</springboot.version>
     <querydsl.version>3.7.0</querydsl.version>
     <jna.version>3.0.9</jna.version>
     <caffeine.version>2.5.0</caffeine.version>
@@ -31,6 +31,7 @@
     <elasticsearch.version>2.4.6</elasticsearch.version>
     <commons-lang3.version>3.7</commons-lang3.version>
     <jsass.version>5.7.0</jsass.version>
+    <javax.annotation>1.3.2</javax.annotation>
   </properties>
 
   <dependencyManagement>
@@ -97,6 +98,11 @@
         <groupId>io.bit3</groupId>
         <artifactId>jsass</artifactId>
         <version>${jsass.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax.annotation}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/blossom-parent/pom.xml
+++ b/blossom-parent/pom.xml
@@ -25,7 +25,7 @@
     <caffeine.version>2.5.0</caffeine.version>
     <bouncycastle.version>1.59</bouncycastle.version>
     <liquibase.version>3.5.3</liquibase.version>
-    <camunda.version>2.2.0</camunda.version>
+    <camunda.version>3.2.0</camunda.version>
     <tika.version>1.19.1</tika.version>
     <powermock.version>1.7.3</powermock.version>
     <elasticsearch.version>2.4.6</elasticsearch.version>
@@ -75,7 +75,7 @@
         <version>${liquibase.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.camunda.bpm.extension.springboot</groupId>
+        <groupId>org.camunda.bpm.springboot</groupId>
         <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
         <version>${camunda.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.0</version>
+            <version>0.8.2</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
The goal of this PR is to allow full Java11 compatibility:
- Projects running with Java11 with no warnings
- Projects building targeting release 11
- Blossom build with Java11, including release targeting to 11 (even if this isn't the case for now)

Changes to this effect:
- Upgrade to Spring Boot 2.1
- Add dependencies to Java modules that are no longer part of the JDK: javax.annotation, jaxb-runtime
- Upgrade maven plugins to versions that support Java 11: Jacoco 0.8.2, maven-javadoc-plugin 3.0.1
- Security upgrade : apache tika to 1.20
- Camunda starter from 2.2.0 to 3.2.0 to work with Spring Boot 2.1
- Removed implicit bean overriding for `MessageSource` since bean overriding is disabled by default with Spring Boot 2.1, instead extending the default MessageSource

Question:
- [x] I chose org.glassfish.jaxb:jaxb-runtime for JAXB implementation, as it was used on some of my projects anyway. I am debating sticking to com.sun.xml.bind:jaxb-impl instead, as it is the default implementation that was packaged with Java