### PR TITLE
Trigger history

### DIFF
--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/SchedulerAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/SchedulerAutoConfiguration.java
@@ -1,21 +1,29 @@
 package com.blossomproject.autoconfigure.core;
 
-import com.blossomproject.core.scheduler.history.TriggerHistoryDao;
-import com.blossomproject.core.scheduler.history.TriggerHistoryDaoImpl;
+import com.blossomproject.core.scheduler.history.*;
 import com.blossomproject.core.scheduler.job.ScheduledJobService;
 import com.blossomproject.core.scheduler.job.ScheduledJobServiceImpl;
 import com.blossomproject.core.scheduler.listener.GlobalTriggerListener;
 import com.blossomproject.core.scheduler.supervision.JobExecutionHealthIndicator;
+import org.quartz.JobDetail;
 import org.quartz.Scheduler;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
+import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+import java.time.Duration;
 
 /**
  * Created by Maël Gargadennnec on 04/05/2017.
@@ -24,11 +32,61 @@ import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 public class SchedulerAutoConfiguration {
 
   @Configuration
+  @ConfigurationProperties("blossom.scheduler")
+  @PropertySource("classpath:/scheduler.properties")
+  public static class BlossomSchedulerConfigurationProperties {
+    private int maxHistorySize;
+    private Duration maxHistoryAge;
+
+    public int getMaxHistorySize() {
+      return maxHistorySize;
+    }
+
+    public void setMaxHistorySize(int maxHistorySize) {
+      this.maxHistorySize = maxHistorySize;
+    }
+
+    public Duration getMaxHistoryAge() {
+      return maxHistoryAge;
+    }
+
+    public void setMaxHistoryAge(Duration maxHistoryAge) {
+      this.maxHistoryAge = maxHistoryAge;
+    }
+  }
+
+  @Bean
+  @Qualifier("triggerHistoryCleanJob")
+  public JobDetailFactoryBean triggerHistoryCleanJob() {
+    JobDetailFactoryBean factoryBean = new JobDetailFactoryBean();
+    factoryBean.setJobClass(TriggerHistoryCleanJob.class);
+    factoryBean.setGroup("Blossom");
+    factoryBean.setName("Quartz trigger history clean");
+    factoryBean.setDescription("Remove old trigger history");
+    factoryBean.setDurability(true);
+    return factoryBean;
+  }
+
+  @Bean
+  @Qualifier("triggerHistoryCleanCronTrigger")
+  public CronTriggerFactoryBean triggerHistoryCleanCronTrigger(
+    @Qualifier("triggerHistoryCleanJob") JobDetail triggerHistoryCleanJob) {
+    CronTriggerFactoryBean factoryBean = new CronTriggerFactoryBean();
+    factoryBean.setJobDetail(triggerHistoryCleanJob);
+    factoryBean.setCronExpression("37 37 * * * ?");
+    return factoryBean;
+  }
+
+
+  @Configuration
   @AutoConfigureBefore(QuartzAutoConfiguration.class)
+  @EntityScan(basePackageClasses = TriggerHistory.class)
+  @EnableJpaRepositories(basePackageClasses = TriggerHistoryRepository.class)
   public static class GlobalListenerQuartzAutoConfiguration {
     @Bean
-    public TriggerHistoryDao triggerHistoryDao(JdbcTemplate jdbcTemplate) {
-      return new TriggerHistoryDaoImpl(jdbcTemplate, 10);
+    public TriggerHistoryDao triggerHistoryDao(TriggerHistoryRepository triggerHistoryRepository,
+                                               BlossomSchedulerConfigurationProperties properties) {
+      return new TriggerHistoryDaoImpl(triggerHistoryRepository, properties.getMaxHistorySize());
     }
 
     @Bean

--- a/blossom-autoconfigure/src/main/resources/scheduler.properties
+++ b/blossom-autoconfigure/src/main/resources/scheduler.properties
@@ -1,2 +1,5 @@
 blossom.scheduler.enabled=true
 blossom.scheduler.name=Default scheduler
+
+blossom.scheduler.max-history-size=10
+blossom.scheduler.max-history-age=15d

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistory.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistory.java
@@ -1,32 +1,84 @@
 package com.blossomproject.core.scheduler.history;
 
 import com.blossomproject.core.common.entity.AbstractEntity;
-import java.sql.Timestamp;
 import org.quartz.JobKey;
 import org.quartz.TriggerKey;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "qrtz_trigger_history")
 public class TriggerHistory extends AbstractEntity {
 
-  private TriggerKey triggerKey;
-  private JobKey jobKey;
+  @Column(name = "trigger_name")
+  private String triggerName;
+  @Column(name = "trigger_group")
+  private String triggerGroup;
+  @Column(name = "job_name")
+  private String jobName;
+  @Column(name = "job_group")
+  private String jobGroup;
+  @Column(name = "fire_instance_id")
   private String fireInstanceId;
+  @Column(name = "start_time")
   private Timestamp startTime;
+  @Column(name = "end_time")
   private Timestamp endTime;
 
   public TriggerKey getTriggerKey() {
-    return triggerKey;
+    return new TriggerKey(triggerName, triggerGroup);
   }
 
+  @Transient
   public void setTriggerKey(TriggerKey triggerKey) {
-    this.triggerKey = triggerKey;
+    this.triggerName = triggerKey.getName();
+    this.triggerGroup = triggerKey.getGroup();
+  }
+
+  public String getTriggerName() {
+    return triggerName;
+  }
+
+  public void setTriggerName(String triggerName) {
+    this.triggerName = triggerName;
+  }
+
+  public String getTriggerGroup() {
+    return triggerGroup;
+  }
+
+  public void setTriggerGroup(String triggerGroup) {
+    this.triggerGroup = triggerGroup;
   }
 
   public JobKey getJobKey() {
-    return jobKey;
+    return new JobKey(jobName, jobGroup);
   }
 
+  @Transient
   public void setJobKey(JobKey jobKey) {
-    this.jobKey = jobKey;
+    this.jobGroup = jobKey.getGroup();
+    this.jobName = jobKey.getName();
+  }
+
+  public String getJobName() {
+    return jobName;
+  }
+
+  public void setJobName(String jobName) {
+    this.jobName = jobName;
+  }
+
+  public String getJobGroup() {
+    return jobGroup;
+  }
+
+  public void setJobGroup(String jobGroup) {
+    this.jobGroup = jobGroup;
   }
 
   public String getFireInstanceId() {

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryCleanJob.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryCleanJob.java
@@ -1,0 +1,32 @@
+package com.blossomproject.core.scheduler.history;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class TriggerHistoryCleanJob implements Job {
+
+  private final TriggerHistoryRepository triggerHistoryRepository;
+  private final Duration maxAge;
+
+  public TriggerHistoryCleanJob(TriggerHistoryRepository triggerHistoryRepository,
+                                @Value("${blossom.scheduler.max-history-age}") Duration maxAge) {
+    this.triggerHistoryRepository = triggerHistoryRepository;
+    this.maxAge = maxAge;
+  }
+
+  @Override
+  @Transactional
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    Timestamp oldestStartTime = new Timestamp(Instant.now().minus(maxAge.getSeconds(), ChronoUnit.SECONDS).getEpochSecond() * 1000);
+    triggerHistoryRepository.deleteAllByStartTimeBefore(oldestStartTime);
+  }
+
+}

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
@@ -27,18 +27,11 @@ public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
   @Transactional
   public List<TriggerHistory> getJobHistory(JobKey jobKey) {
     try {
-      List<TriggerHistory> histories = repository.getByJobNameAndJobGroup(
+      return repository.getByJobNameAndJobGroup(
         jobKey.getName(),
         jobKey.getGroup(),
         PageRequest.of(0, maxHistorySize + 1, Sort.Direction.DESC, "startTime")
       );
-
-      if (histories.isEmpty()) {
-        return Collections.emptyList();
-      }
-
-      return histories;
-
     } catch (Exception e) {
       logger.error("Cannot get last TriggerHistory", e);
       return Collections.emptyList();

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
@@ -1,58 +1,41 @@
 package com.blossomproject.core.scheduler.history;
 
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.quartz.JobKey;
-import org.quartz.TriggerKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.List;
 
 public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
 
   private final static Logger logger = LoggerFactory.getLogger(TriggerHistoryDaoImpl.class);
 
-  private final static String TABLE_NAME = "qrtz_trigger_history";
-  private final static RowMapper<TriggerHistory> mapper = (rs, rowNum) -> {
-    TriggerHistory triggerHistory = new TriggerHistory();
-    triggerHistory.setId(rs.getLong("id"));
-    triggerHistory.setCreationDate(rs.getDate("creation_date"));
-    triggerHistory.setCreationUser(rs.getString("creation_user"));
-    triggerHistory.setModificationDate(rs.getDate("modification_date"));
-    triggerHistory.setModificationUser(rs.getString("modification_user"));
-    triggerHistory.setFireInstanceId(rs.getString("fire_instance_id"));
-    triggerHistory.setStartTime(rs.getTimestamp("start_time"));
-    triggerHistory.setEndTime(rs.getTimestamp("end_time"));
-    triggerHistory
-      .setJobKey(new JobKey(rs.getString("job_name"), rs.getString("job_group")));
-    triggerHistory
-      .setTriggerKey(new TriggerKey(rs.getString("trigger_name"), rs.getString("trigger_group")));
-    return triggerHistory;
-  };
-  private final JdbcTemplate jdbcTemplate;
+  private final TriggerHistoryRepository repository;
   private final Integer maxHistorySize;
 
-  public TriggerHistoryDaoImpl(JdbcTemplate jdbcTemplate, Integer maxHistorySize) {
-    this.jdbcTemplate = jdbcTemplate;
+  public TriggerHistoryDaoImpl(TriggerHistoryRepository repository, Integer maxHistorySize) {
+    this.repository = repository;
     this.maxHistorySize = maxHistorySize;
   }
 
   @Override
+  @Transactional
   public List<TriggerHistory> getJobHistory(JobKey jobKey) {
-    List<TriggerHistory> history = null;
+    List<TriggerHistory> history;
     try {
-      List<TriggerHistory> histories = jdbcTemplate.query(
-        "select * from " + TABLE_NAME
-          + " where job_group=? and job_name=? order by start_time desc",
-        new Object[]{jobKey.getGroup(), jobKey.getName()},
-        mapper);
+      List<TriggerHistory> histories = repository.getByJobNameAndJobGroup(
+        jobKey.getName(),
+        jobKey.getGroup(),
+        PageRequest.of(0, maxHistorySize + 1, Sort.Direction.DESC, "startTime")
+      );
 
       if (histories.isEmpty()) {
-        return new ArrayList<>();
+        return Collections.emptyList();
       }
 
       if (histories.size() > this.maxHistorySize) {
@@ -62,46 +45,30 @@ public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
         history = histories;
       }
       return history;
+
     } catch (Exception e) {
       logger.error("Cannot get last TriggerHistory", e);
-      return history;
+      return Collections.emptyList();
     }
   }
 
   private void cleanHistory(JobKey jobKey, Timestamp olderThan) {
-    this.jdbcTemplate
-      .update("DELETE FROM " + TABLE_NAME + " WHERE job_group=? and job_name=? and start_time <= ?",
-        jobKey.getGroup(), jobKey.getName(), olderThan);
+    repository.deleteByJobNameAndJobGroupAndStartTimeBefore(jobKey.getName(), jobKey.getGroup(), olderThan);
   }
 
   @Override
   @Transactional
   public void create(TriggerHistory triggerHistory) {
-    Timestamp now = new Timestamp(System.currentTimeMillis());
-    jdbcTemplate.update(
-      "INSERT INTO " + TABLE_NAME
-        + "(id, creation_date, creation_user,modification_date,modification_user, fire_instance_id,start_time,end_time,job_group,job_name,trigger_group,trigger_name) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
-      triggerHistory.getId(),
-      now,
-      "scheduler",
-      now,
-      "scheduler",
-      triggerHistory.getFireInstanceId(),
-      triggerHistory.getStartTime(),
-      triggerHistory.getEndTime(),
-      triggerHistory.getJobKey().getGroup(),
-      triggerHistory.getJobKey().getName(),
-      triggerHistory.getTriggerKey().getGroup(),
-      triggerHistory.getTriggerKey().getName()
-    );
+    triggerHistory.setCreationUser("scheduler");
+    triggerHistory.setModificationUser("scheduler");
+    repository.save(triggerHistory);
   }
 
   @Override
   @Transactional
   public void updateEndDate(String fireInstanceId) {
-    jdbcTemplate.update(
-      "update " + TABLE_NAME + " set end_time=? where fire_instance_id=?",
-      new Timestamp(System.currentTimeMillis()),
-      fireInstanceId);
+    TriggerHistory triggerHistory = repository.getFirstByFireInstanceId(fireInstanceId);
+    triggerHistory.setEndTime(new Timestamp(System.currentTimeMillis()));
+    repository.save(triggerHistory);
   }
 }

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryDaoImpl.java
@@ -26,7 +26,6 @@ public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
   @Override
   @Transactional
   public List<TriggerHistory> getJobHistory(JobKey jobKey) {
-    List<TriggerHistory> history;
     try {
       List<TriggerHistory> histories = repository.getByJobNameAndJobGroup(
         jobKey.getName(),
@@ -38,22 +37,12 @@ public class TriggerHistoryDaoImpl implements TriggerHistoryDao {
         return Collections.emptyList();
       }
 
-      if (histories.size() > this.maxHistorySize) {
-        this.cleanHistory(jobKey, histories.get(this.maxHistorySize).getStartTime());
-        history = histories.subList(0, this.maxHistorySize);
-      } else {
-        history = histories;
-      }
-      return history;
+      return histories;
 
     } catch (Exception e) {
       logger.error("Cannot get last TriggerHistory", e);
       return Collections.emptyList();
     }
-  }
-
-  private void cleanHistory(JobKey jobKey, Timestamp olderThan) {
-    repository.deleteByJobNameAndJobGroupAndStartTimeBefore(jobKey.getName(), jobKey.getGroup(), olderThan);
   }
 
   @Override

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryRepository.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryRepository.java
@@ -12,8 +12,6 @@ public interface TriggerHistoryRepository extends JpaRepository<TriggerHistory, 
 
   List<TriggerHistory> getByJobNameAndJobGroup(String jobName, String jobGroup, Pageable page);
 
-  void deleteByJobNameAndJobGroupAndStartTimeBefore(String jobName, String jobGroup, Timestamp date);
-
   void deleteAllByStartTimeBefore(Timestamp date);
 
   TriggerHistory getFirstByFireInstanceId(String fireIstanceId);

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryRepository.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryRepository.java
@@ -14,6 +14,6 @@ public interface TriggerHistoryRepository extends JpaRepository<TriggerHistory, 
 
   void deleteAllByStartTimeBefore(Timestamp date);
 
-  TriggerHistory getFirstByFireInstanceId(String fireIstanceId);
+  TriggerHistory getFirstByFireInstanceId(String fireInstanceId);
 
 }

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryRepository.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/history/TriggerHistoryRepository.java
@@ -1,0 +1,21 @@
+package com.blossomproject.core.scheduler.history;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Repository
+public interface TriggerHistoryRepository extends JpaRepository<TriggerHistory, Long> {
+
+  List<TriggerHistory> getByJobNameAndJobGroup(String jobName, String jobGroup, Pageable page);
+
+  void deleteByJobNameAndJobGroupAndStartTimeBefore(String jobName, String jobGroup, Timestamp date);
+
+  void deleteAllByStartTimeBefore(Timestamp date);
+
+  TriggerHistory getFirstByFireInstanceId(String fireIstanceId);
+
+}

--- a/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/listener/GlobalTriggerListener.java
+++ b/blossom-core/blossom-core-scheduler/src/main/java/com/blossomproject/core/scheduler/listener/GlobalTriggerListener.java
@@ -47,15 +47,15 @@ public class GlobalTriggerListener implements TriggerListener {
         trigger.getJobKey().getGroup(), trigger.getJobKey().getName());
     }
 
-    TriggerHistory history = new TriggerHistory();
-    history.ensureId();
-    history.setFireInstanceId(context.getFireInstanceId());
-    history.setJobKey(trigger.getJobKey());
-    history.setTriggerKey(trigger.getKey());
-    history.setStartTime(new Timestamp(context.getFireTime().getTime()));
-    history.setEndTime(null);
-
     try {
+      TriggerHistory history = new TriggerHistory();
+      history.ensureId();
+      history.setFireInstanceId(context.getFireInstanceId());
+      history.setJobKey(trigger.getJobKey());
+      history.setTriggerKey(trigger.getKey());
+      history.setStartTime(new Timestamp(context.getFireTime().getTime()));
+      history.setEndTime(null);
+
       triggerHistoryDao.create(history);
     } catch (Exception e) {
       logger.error("Error trying to save trigger firing information", e);

--- a/blossom-core/blossom-core-scheduler/src/test/java/com/blossomproject/core/scheduler/listener/GlobalTriggerListenerTest.java
+++ b/blossom-core/blossom-core-scheduler/src/test/java/com/blossomproject/core/scheduler/listener/GlobalTriggerListenerTest.java
@@ -96,6 +96,8 @@ public class GlobalTriggerListenerTest {
   @Test
   public void should_not_throw_any_exception_on_trigger_fired() {
     Trigger trigger = mock(Trigger.class);
+    when(trigger.getJobKey()).thenReturn(new JobKey("job","group"));
+    when(trigger.getKey()).thenReturn(new TriggerKey("trigger","group"));
 
     JobExecutionContext context = mock(JobExecutionContext.class);
     when(context.getFireInstanceId()).thenReturn("fireInstanceId");


### PR DESCRIPTION
- Delegate TriggerHistory DB access to a JPARepository
- When getting JobInfo, actually load only the first "max-history-size" triggers
- Periodically delete all trigger history older than "max-history-age" (default 15 days)