### PR TITLE
Autoconfiguration improvements

### DIFF
--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/ActuatorAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/ActuatorAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.trace.http.HttpTraceAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,7 @@ import java.util.Set;
 @AutoConfigureAfter(ElasticsearchAutoConfiguration.class)
 @AutoConfigureBefore(HttpTraceAutoConfiguration.class)
 @PropertySource("classpath:/actuator.properties")
+@ConditionalOnBean({ElasticsearchAutoConfiguration.class})
 public class ActuatorAutoConfiguration {
 
   @Configuration("BlossomActuatorAutoConfigurationTraceProperties")

--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/CommonAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/core/CommonAutoConfiguration.java
@@ -9,13 +9,6 @@ import com.blossomproject.core.common.utils.privilege.Privilege;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.apache.tika.Tika;
-import org.elasticsearch.action.bulk.BulkProcessor;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.TimeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -53,7 +46,6 @@ import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -104,36 +96,6 @@ public class CommonAutoConfiguration {
   @ConditionalOnMissingBean(PasswordEncoder.class)
   public PasswordEncoder passwordEncoder(SecureRandom secureRandom) {
     return new BCryptPasswordEncoder(10, secureRandom);
-  }
-
-  @Bean
-  @ConditionalOnMissingBean(BulkProcessor.class)
-  public BulkProcessor bulkProcessor(Client client) {
-    return BulkProcessor.builder(client, new BulkProcessor.Listener() {
-
-      @Override
-      public void beforeBulk(long executionId, BulkRequest request) {
-        logger.info("Before bulk {} with {} actions to execute", executionId,
-          request.numberOfActions());
-      }
-
-      @Override
-      public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
-        logger.error("Error on bulk {} with {} actions to execute", executionId,
-          request.numberOfActions(), failure);
-      }
-
-      @Override
-      public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
-        logger.info("Successful bulk {} with {} actions executed in {} ms.", executionId,
-          request.numberOfActions(), response.getTookInMillis());
-      }
-    })
-      .setName("Blossom Bulk Processor")
-      .setBulkActions(500)
-      .setBulkSize(new ByteSizeValue(10, ByteSizeUnit.MB))
-      .setFlushInterval(new TimeValue(30, TimeUnit.SECONDS))
-      .build();
   }
 
   @Bean

--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/MenuAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/MenuAutoConfiguration.java
@@ -12,6 +12,7 @@ import com.blossomproject.ui.menu.MenuItemPlugin;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +29,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @EnablePluginRegistries({MenuItemPlugin.class})
 @ConditionalOnWebApplication
+@ConditionalOnClass({Menu.class})
 public class MenuAutoConfiguration {
 
   @Autowired

--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/ThemeAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/ThemeAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -46,6 +47,7 @@ import org.springframework.web.servlet.theme.ThemeChangeInterceptor;
 @Configuration
 @EnablePluginRegistries({Theme.class})
 @ConditionalOnWebApplication
+@ConditionalOnClass({Theme.class})
 @EnableConfigurationProperties(BlossomThemeProperties.class)
 public class ThemeAutoConfiguration {
 

--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/WebContextAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/WebContextAutoConfiguration.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
@@ -37,6 +38,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  */
 @Configuration
 @ConditionalOnWebApplication
+@ConditionalOnClass({FilterHandlerMethodArgumentResolver.class})
 @AutoConfigureBefore({WebMvcAutoConfiguration.class, ErrorMvcAutoConfiguration.class})
 public class WebContextAutoConfiguration implements WebMvcConfigurer {
 

--- a/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/WebSecurityAutoConfiguration.java
+++ b/blossom-autoconfigure/src/main/java/com/blossomproject/autoconfigure/ui/WebSecurityAutoConfiguration.java
@@ -13,6 +13,7 @@ import com.blossomproject.ui.security.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -41,6 +42,7 @@ import static com.blossomproject.autoconfigure.ui.WebContextAutoConfiguration.BL
  */
 @Configuration
 @ConditionalOnWebApplication
+@ConditionalOnClass({AuthenticationFailureListener.class})
 @Order(SecurityProperties.DEFAULT_FILTER_ORDER)
 @PropertySource("classpath:/security.properties")
 @EnableConfigurationProperties({DefaultAccountProperties.class, BlossomWebBackOfficeProperties.class})


### PR DESCRIPTION
Make the autoconfiguration fail less often when some dependencies are not present:
- Allow web applications to not depend on blossom-ui-common
- Do not create / depend on an Elasticsearch Client when Elasticsearch is not present