### PR TITLE
Build with OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 sudo: false
 
 env:


### PR DESCRIPTION
Oracle JDK 8 has been out of support for a while, and it seems Travis removed support for it.

This PR switches the build to use OpenJDK 8