### PR TITLE
Fix for issue 233

### DIFF
--- a/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/dao/GenericReadOnlyDaoImpl.java
+++ b/blossom-core/blossom-core-common/src/main/java/com/blossomproject/core/common/dao/GenericReadOnlyDaoImpl.java
@@ -35,7 +35,7 @@ public abstract class GenericReadOnlyDaoImpl<ENTITY extends AbstractEntity> impl
   protected TypeToken<ENTITY> type = new TypeToken<ENTITY>(getClass()) {
   };
 
-  GenericReadOnlyDaoImpl(CrudRepository<ENTITY> repository) {
+  public GenericReadOnlyDaoImpl(CrudRepository<ENTITY> repository) {
     Preconditions.checkNotNull(repository);
     this.repository = repository;
   }


### PR DESCRIPTION
Making the constructor of GenricReadOnlyDaoImpl public as it makes no senss for it to be package protected as its purpose is to be inherited